### PR TITLE
Fix json parse error

### DIFF
--- a/src/main/java/com/bettercloud/vault/api/Logical.java
+++ b/src/main/java/com/bettercloud/vault/api/Logical.java
@@ -77,7 +77,7 @@ public final class Logical {
                 final Map<String, String> data = new HashMap<String, String>();//NOPMD
                 for (final JsonObject.Member member : Json.parse(jsonString).asObject().get("data").asObject()) {
                     final JsonValue jsonValue = member.getValue();
-                    data.put(member.getName(), jsonValue.isNull() ? null : jsonValue.asString());
+                    data.put(member.getName(), jsonValue.isNull() ? null : jsonValue.toString());
                 }
                 return new LogicalResponse(restResponse, retryCount, data);
             } catch (Exception e) {


### PR DESCRIPTION
When using the aws secret backend `aws/creds/name` the following error
would be thrown.

```
Caused by: java.lang.UnsupportedOperationException: Not a string: null
    at com.bettercloud.vault.json.JsonValue.asString(JsonValue.java:389)
    at com.bettercloud.vault.api.Logical.read(Logical.java:78)
```
It looks like it is the `null` returned in the `security_token` field may be the problem as it is not a string type.
```
{
        "lease_id": "some_id",
        "lease_duration": 7200,
        "renewable": true,
        "data": {
                "access_key": "some_access_key",
                "secret_key": "some_secret_key",
                "security_token": null
        },
        "warnings": null
}
```