### PR TITLE
Implement github auth

### DIFF
--- a/src/main/java/com/bettercloud/vault/api/Auth.java
+++ b/src/main/java/com/bettercloud/vault/api/Auth.java
@@ -253,7 +253,7 @@ public class Auth {
     }
 
      /**
-     * <p>Basic login operation to authenticate to an app-id backend.  Example usage:</p>
+     * <p>Basic login operation to authenticate to an github backend.  Example usage:</p>
      *
      * <blockquote>
      * <pre>{@code


### PR DESCRIPTION
Couple notes:

1) I removed the path parameter that the [app-id auth](https://github.com/BetterCloud/vault-java-driver/blob/master/src/main/java/com/bettercloud/vault/api/Auth.java#L162) has.  I don't see why it needs to be dynamic (though perhaps you guys can provide more insight into it).  I ultimately decided to remove it based on the [ruby example](https://github.com/hashicorp/vault-ruby/blob/master/lib/vault/api/auth.rb#L136).  If you guys agree, then you may want to consider removing it from the app-id authentication as well

2) I did not add integration tests.  I do see that they are [here](https://github.com/BetterCloud/vault-java-driver/blob/master/src/test-integration/java/com/bettercloud/vault/api/AuthTests.java), but given that we are testing actual authentication with a running vault service, we would need an actual github token to use here.  If you guys have any ideas as to how to test this, please let me know and I'll be happy to make the requisite changes.

3) I initially had some trouble compiling this and testing this (though to be clear, I have tested this out and it works).  It seems that the [gradle.properties](https://github.com/BetterCloud/vault-java-driver/blob/master/gradle.properties) should bypass this, but it does not appear to.  I was able to bypass the issue with [this](http://stackoverflow.com/a/27741137/1680714) in the `build.gradle`, but I don't think you'll want that committed.

If you're curious, this is the error I was getting:

```
# gradle

FAILURE: Build failed with an exception.

* Where:
Build file '..../vault-java-driver/build.gradle' line: 137

* What went wrong:
A problem occurred evaluating root project 'vault-java-driver'.
> No such property: ossrhUsername for class: org.gradle.api.publication.maven.internal.deployer.DefaultGroovyMavenDeployer

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 3.78 secs
```

Let me know if you have any questions or comments.