### PR TITLE
Allow unexpected response codes to be easily checked

### DIFF
--- a/src/main/java/com/bettercloud/vault/VaultException.java
+++ b/src/main/java/com/bettercloud/vault/VaultException.java
@@ -1,6 +1,7 @@
 package com.bettercloud.vault;
 
 public class VaultException extends Exception {
+    private static final long serialVersionUID = 1757161544243811489L;
 
     public VaultException(final String message) {
         super(message);

--- a/src/main/java/com/bettercloud/vault/VaultResponseException.java
+++ b/src/main/java/com/bettercloud/vault/VaultResponseException.java
@@ -1,0 +1,17 @@
+package com.bettercloud.vault;
+
+public class VaultResponseException extends VaultException {
+    private static final long serialVersionUID = 7622562542614338888L;
+
+    private final int responseCode;
+
+    public VaultResponseException(int responseCode) {
+        super("Vault responded with HTTP status code: " + responseCode);
+
+        this.responseCode = responseCode;
+    }
+
+    public int getResponseCode() {
+        return responseCode;
+    }
+}

--- a/src/main/java/com/bettercloud/vault/api/Auth.java
+++ b/src/main/java/com/bettercloud/vault/api/Auth.java
@@ -2,6 +2,7 @@ package com.bettercloud.vault.api;
 
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.VaultResponseException;
 import com.bettercloud.vault.json.Json;
 import com.bettercloud.vault.json.JsonArray;
 import com.bettercloud.vault.json.JsonObject;
@@ -110,7 +111,7 @@ public class Auth {
 
                 // Validate restResponse
                 if (restResponse.getStatus() != 200) {
-                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus());
+                    throw new VaultResponseException(restResponse.getStatus());
                 }
                 final String mimeType = restResponse.getMimeType() == null ? "null" : restResponse.getMimeType();
                 if (!mimeType.equals("application/json")) {
@@ -169,7 +170,7 @@ public class Auth {
 
                 // Validate restResponse
                 if (restResponse.getStatus() != 200) {
-                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus());
+                    throw new VaultResponseException(restResponse.getStatus());
                 }
                 final String mimeType = restResponse.getMimeType() == null ? "null" : restResponse.getMimeType();
                 if (!mimeType.equals("application/json")) {
@@ -227,7 +228,7 @@ public class Auth {
 
                 // Validate restResponse
                 if (restResponse.getStatus() != 200) {
-                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus());
+                    throw new VaultResponseException(restResponse.getStatus());
                 }
                 final String mimeType = restResponse.getMimeType() == null ? "null" : restResponse.getMimeType();
                 if (!mimeType.equals("application/json")) {
@@ -288,7 +289,7 @@ public class Auth {
                         .post();
                 // Validate restResponse
                 if (restResponse.getStatus() != 200) {
-                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus());
+                    throw new VaultResponseException(restResponse.getStatus());
                 }
                 final String mimeType = restResponse.getMimeType() == null ? "null" : restResponse.getMimeType();
                 if (!mimeType.equals("application/json")) {

--- a/src/main/java/com/bettercloud/vault/api/Debug.java
+++ b/src/main/java/com/bettercloud/vault/api/Debug.java
@@ -2,6 +2,7 @@ package com.bettercloud.vault.api;
 
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.VaultResponseException;
 import com.bettercloud.vault.response.HealthResponse;
 import com.bettercloud.vault.rest.Rest;
 import com.bettercloud.vault.rest.RestException;
@@ -130,7 +131,7 @@ public class Debug {
                 if (standbyCode != null) validCodes.add(standbyCode);
                 if (sealedCode != null) validCodes.add(sealedCode);
                 if (!validCodes.contains(restResponse.getStatus())) {
-                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus());
+                    throw new VaultResponseException(restResponse.getStatus());
                 }
                 return new HealthResponse(restResponse, retryCount);
             } catch (RuntimeException | VaultException | RestException e) {

--- a/src/main/java/com/bettercloud/vault/api/Logical.java
+++ b/src/main/java/com/bettercloud/vault/api/Logical.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.VaultResponseException;
 import com.bettercloud.vault.json.Json;
 import com.bettercloud.vault.json.JsonArray;
 import com.bettercloud.vault.json.JsonObject;
@@ -64,7 +65,7 @@ public class Logical {
 
                 // Validate response
                 if (restResponse.getStatus() != 200) {
-                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus());
+                    throw new VaultResponseException(restResponse.getStatus());
                 }
 
                 final Map<String, String> data = parseResponseData(restResponse);
@@ -132,7 +133,7 @@ public class Logical {
                     final Map<String, String> data = parseResponseData(restResponse);
                     return new LogicalResponse(restResponse, retryCount, data);
                 } else {
-                    throw new VaultException("Expecting HTTP status 204 or 200, but instead receiving " + restStatus);
+                    throw new VaultResponseException(restStatus);
                 }
             } catch (Exception e) {
                 // If there are retries to perform, then pause for the configured interval and then execute the loop again...
@@ -206,7 +207,7 @@ public class Logical {
 
                 // Validate response
                 if (restResponse.getStatus() != 204) {
-                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus());
+                    throw new VaultResponseException(restResponse.getStatus());
                 }
                 return new LogicalResponse(restResponse, retryCount);
             } catch (RuntimeException | VaultException | RestException e) {

--- a/src/main/java/com/bettercloud/vault/api/pki/Pki.java
+++ b/src/main/java/com/bettercloud/vault/api/pki/Pki.java
@@ -2,6 +2,7 @@ package com.bettercloud.vault.api.pki;
 
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.VaultResponseException;
 import com.bettercloud.vault.json.Json;
 import com.bettercloud.vault.json.JsonObject;
 import com.bettercloud.vault.json.JsonValue;
@@ -96,7 +97,7 @@ public class Pki {
 
                 // Validate restResponse
                 if (restResponse.getStatus() != 204) {
-                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus());
+                    throw new VaultResponseException(restResponse.getStatus());
                 }
                 return new PkiResponse(restResponse, retryCount);
             } catch (Exception e) {
@@ -154,7 +155,7 @@ public class Pki {
 
                 // Validate response
                 if (restResponse.getStatus() != 200 && restResponse.getStatus() != 404) {
-                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus());
+                    throw new VaultResponseException(restResponse.getStatus());
                 }
 
                 final Map<String, String> data = restResponse.getBody() == null || restResponse.getBody().length == 0
@@ -216,7 +217,7 @@ public class Pki {
 
                 // Validate response
                 if (restResponse.getStatus() != 204) {
-                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus());
+                    throw new VaultResponseException(restResponse.getStatus());
                 }
                 return new PkiResponse(restResponse, retryCount);
             } catch (Exception e) {
@@ -322,7 +323,7 @@ public class Pki {
 
                 // Validate response
                 if (restResponse.getStatus() != 200 && restResponse.getStatus() != 404) {
-                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus());
+                    throw new VaultResponseException(restResponse.getStatus());
                 }
 
                 final Map<String, String> data = restResponse.getBody() == null || restResponse.getBody().length == 0


### PR DESCRIPTION
In conditions where previously a opaque `VaultException` would be thrown due to an unexpected response code, we now throw a `VaultResponseException`.
This exception extends `VaultException`, allowing previous error handling code to function the same way.  However it provides the additional ability to easily get at the numeric response code without needing to parse the exception message.

This can be useful to users (aka me) of the library in that it allows them to have more specific error handling capabilities.