### PR TITLE
Dockerized integration test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,9 @@ archivesBaseName = 'vault-java-driver'
 version '1.1.0'
 
 //noinspection GroovyUnusedAssignment
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 //noinspection GroovyUnusedAssignment
-targetCompatibility = 1.7
+targetCompatibility = 1.8
 
 repositories {
     mavenCentral()
@@ -42,6 +42,9 @@ dependencies {
     testCompile('junit:junit:4.11')
     testCompile('org.mockito:mockito-core:1.10.19')
     testCompile('org.eclipse.jetty:jetty-server:9.3.7.v20160115')
+    testCompile('org.testcontainers:testcontainers:1.1.3')
+    testCompile('org.slf4j:slf4j-api:1.7.21')
+    testRuntime('org.slf4j:slf4j-simple:1.7.21')
 }
 
 task wrapper(type: Wrapper) {
@@ -98,13 +101,6 @@ task integrationTest(type: Test) {
     testLogging {
         events "passed", "skipped", "failed"
     }
-    systemProperties = [
-        VAULT_ADDR: System.getProperty("VAULT_ADDR"),
-        VAULT_TOKEN: System.getProperty("VAULT_TOKEN"),
-        VAULT_APP_ID: System.getProperty("VAULT_APP_ID"),
-        VAULT_USER_ID: System.getProperty("VAULT_USER_ID"),
-        VAULT_PASSWORD: System.getProperty("VAULT_PASSWORD")
-    ]
 }
 
 //
@@ -172,4 +168,3 @@ uploadArchives {
         }
     }
 }
-

--- a/src/test-integration/README.md
+++ b/src/test-integration/README.md
@@ -1,76 +1,9 @@
 Intro
 =====
 Unit tests, which do not rely on a Vault server being available, are separated from
-these integration tests, which do require a Vault instance.
+these integration tests, which do require a Vault instance.  
 
-Configuring a Vault Server
-==========================
-It's not necessary to have a production-grade Vault server.  To run these tests, you
-can simply run a [Dev Server](https://www.vaultproject.io/intro/getting-started/dev-server.html)
-process:
-
-```
-$ vault server -dev`
-
-==> WARNING: Dev mode is enabled!
-
-In this mode, Vault is completely in-memory and unsealed.
-Vault is configured to only have a single unseal key. The root
-token has already been authenticated with the CLI, so you can
-immediately begin using the Vault CLI.
-
-The only step you need to take is to set the following
-environment variables:
-
-    set VAULT_ADDR=http://127.0.0.1:8200
-
-The unseal key and root token are reproduced below in case you
-want to seal/unseal the Vault or play with authentication.
-
-Unseal Key: 642e33b1c397c292743df56da6129a25df6a6349934931f55a2baac34a6e2c80
-Root Token: 764cf317-d3b9-3d52-dc7d-e4f0198f6a8c
-
-...
-```
-
-Some of the integration tests verify that an authentication  token can be retrieved
-from various auth backends (e.g. [App Id](https://www.vaultproject.io/docs/auth/app-id.html),
-[Username & Password](https://www.vaultproject.io/docs/auth/userpass.html), etc).
-So prior to running these tests, you will need to run some Vault CLI commands to
-enable auth backends and populate user and app data:
-
-```
-vault auth-enable app-id
-vault write auth/app-id/map/app-id/fake_app value=root display_name=fake_app
-vault write auth/app-id/map/user-id/fake_user value=fake_app
-
-vault auth-enable userpass
-vault write auth/userpass/users/fake_user password=fake_password policies=root
-
-vault mount -path=pki pki
-vault write pki/root/generate/internal common_name=myvault.com ttl=99h
-```
-
-Configuring and Running the Integration Tests
-=============================================
-The Gradle `integrationTest` task is used to execute the integration test suite.
-When running this Gradle task, you need to pass several JVM options so that Gradle
-will make them available to the tests:
-
-* `VAULT_ADDR`: The connection URL for the Vault server.  The Dev Server displays
-  this when the server starts up (e.g. `http://127.0.0.1:8200`) in the example above.
-* `VAULT_TOKEN`: The root token, to enable Vault API calls.  The Dev Server also
-  displays this at startup (e.g. `764cf317-d3b9-3d52-dc7d-e4f0198f6a8c` in the
-  example above).
-* `VAULT_APP_ID`: An application ID that has been created in the Vault server,
-  for testing the App Id auth backend.  This can be whatever you populate (e.g.
-  `fake_app` in the example CLI command above).
-* `VAULT_USER_ID`: A user ID that has been created in the Vault server, for testing
-  the Username and Password auth backend.  This can be whatever you populate (e.g.
-  `fake_user` in the example CLI command above).
-* `VAULT_PASSWORD`: The password corresponding to the above user (e.g. `fake_password`
-  in the CLI command above).
-
-Example Gradle invocation:
-
-`$ gradle integrationTest -DVAULT_ADDR=http://127.0.0.1:8200 -DVAULT_TOKEN=764cf317-d3b9-3d52-dc7d-e4f0198f6a8c -DVAULT_APP_ID=fake_app -DVAULT_USER_ID=fake_user -DVAULT_PASSWORD=fake_password`
+The Vault instance is provisioned automatically as a Docker container, using the 
+[TestContainers library](http://testcontainers.viewdocs.io/testcontainers-java/).  
+Follow that library's documentation for getting your environment set up to run 
+these tests.

--- a/src/test-integration/java/com/bettercloud/vault/api/SysDebugTests.java
+++ b/src/test-integration/java/com/bettercloud/vault/api/SysDebugTests.java
@@ -1,11 +1,9 @@
 package com.bettercloud.vault.api;
 
 import com.bettercloud.vault.Vault;
-import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
 import com.bettercloud.vault.response.HealthResponse;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import static junit.framework.TestCase.*;
@@ -19,25 +17,14 @@ import static junit.framework.TestCase.*;
  */
 public class SysDebugTests {
 
-    private static final String address = System.getProperty("VAULT_ADDR");
-    private static final String token = System.getProperty("VAULT_TOKEN");
+    final static String rootToken = "36303304-3f53-a0c9-af5d-3ffc8dabe683";
 
-    private Vault vault;
-
-    @BeforeClass
-    public static void verifyEnv() {
-        assertNotNull(address);
-        assertNotNull(token);
-    }
-
-    @Before
-    public void setup() throws VaultException {
-        final VaultConfig config = new VaultConfig(address);
-        vault = new Vault(config);
-    }
+    @ClassRule
+    public static final VaultContainer container = new VaultContainer(rootToken);
 
     @Test
     public void testHealth_Plain() throws VaultException {
+        final Vault vault = container.getRootVault();
         final HealthResponse response = vault.sys().debug().health();
         assertTrue(response.getInitialized());
         assertFalse(response.getSealed());
@@ -48,7 +35,7 @@ public class SysDebugTests {
 
     @Test
     public void testHealth_WithToken() throws VaultException {
-        final Vault localVault = new Vault(new VaultConfig(address, token));
+        final Vault localVault = container.getRootVault();
         final HealthResponse response = localVault.sys().debug().health();
         assertTrue(response.getInitialized());
         assertFalse(response.getSealed());
@@ -59,6 +46,7 @@ public class SysDebugTests {
 
     @Test
     public void testHealth_WithParams() throws VaultException {
+        final Vault vault = container.getRootVault();
         final HealthResponse response = vault.sys().debug().health(null, 212, null, null);
         assertTrue(response.getInitialized());
         assertFalse(response.getSealed());
@@ -77,6 +65,7 @@ public class SysDebugTests {
      */
     @Test
     public void testHealth_WonkyActiveCode() throws VaultException {
+        final Vault vault = container.getRootVault();
         final HealthResponse response = vault.sys().debug().health(null, 204, null, null);
         assertNull(response.getInitialized());
         assertNull(response.getSealed());

--- a/src/test-integration/java/com/bettercloud/vault/api/VaultContainer.java
+++ b/src/test-integration/java/com/bettercloud/vault/api/VaultContainer.java
@@ -1,0 +1,103 @@
+package com.bettercloud.vault.api;
+
+import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.VaultConfig;
+import com.bettercloud.vault.VaultException;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+
+import java.io.IOException;
+
+/**
+ * @author Luis Casillas
+ */
+public class VaultContainer implements TestRule {
+    private static final Logger log = LoggerFactory.getLogger(VaultContainer.class);
+
+    private static final int MAX_RETRIES = 5;
+    private static final int RETRY_MILLIS = 1000;
+
+    private final String rootToken;
+    private final GenericContainer vault;
+
+    public VaultContainer(String rootToken) {
+        this.rootToken = rootToken;
+        this.vault = new GenericContainer("vault:v0.6.0")
+                .withExposedPorts(8200)
+                .withEnv("VAULT_DEV_LISTEN_ADDRESS", "0.0.0.0:8200")
+                .withEnv("VAULT_DEV_ROOT_TOKEN_ID", rootToken)
+                .withEnv("VAULT_ADDR", "http://127.0.0.1:8200");
+    }
+
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return vault.apply(base, description);
+    }
+
+
+    public void followOutput() {
+        Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(log);
+        vault.followOutput(logConsumer);
+    }
+
+    public Vault getRootVault() throws VaultException {
+        return getVault(rootToken).withRetries(MAX_RETRIES, RETRY_MILLIS);
+    }
+
+    public Vault getVault() throws VaultException {
+        VaultConfig config =
+                new VaultConfig()
+                        .address(getAddress())
+                        .openTimeout(5)
+                        .readTimeout(30)
+                        .sslVerify(false)
+                        .build();
+        return new Vault(config).withRetries(MAX_RETRIES, RETRY_MILLIS);
+    }
+
+    public Vault getVault(String token) throws VaultException {
+        VaultConfig config =
+                new VaultConfig()
+                        .address(getAddress())
+                        .token(token)
+                        .openTimeout(5)
+                        .readTimeout(30)
+                        .sslVerify(false)
+                        .build();
+        return new Vault(config).withRetries(MAX_RETRIES, RETRY_MILLIS);
+    }
+
+    public String getAddress() {
+        // FIXME: If this address ends with a slash (`"http://%s:%d/"`), tests fail!
+        return String.format("http://%s:%d", vault.getContainerIpAddress(), vault.getMappedPort(8200));
+    }
+
+    public Container.ExecResult runCommand(String... command) throws IOException, InterruptedException {
+        Container.ExecResult result = vault.execInContainer(command);
+        log.debug("Command stdout: {}", result.getStdout());
+        log.debug("Command stderr: {}", result.getStderr());
+        return result;
+    }
+
+    public void createAuthExample(String appId, String userId, String password)
+            throws IOException, InterruptedException {
+        runCommand("vault", "auth-enable", "app-id");
+        runCommand("vault", "write", "auth/app-id/map/app-id/" + appId, "value=root", "display_name=" + appId);
+        runCommand("vault", "write", "auth/app-id/map/user-id/" + userId, "value=" + appId);
+
+        runCommand("vault", "auth-enable", "userpass");
+        runCommand("vault", "write", "auth/userpass/users/" + userId, "password=" + password, "policies=root");
+    }
+
+    public void createPkiExample() throws IOException, InterruptedException {
+        runCommand("vault", "mount", "-path=pki", "pki");
+        runCommand("vault", "write", "pki/root/generate/internal", "common_name=myvault.com", "ttl=99h");
+    }
+}


### PR DESCRIPTION
This patch changes the integration test suite to use the [TestContainers](http://testcontainers.viewdocs.io/testcontainers-java/) library to provision Vault as Docker containers from [the official image](https://hub.docker.com/_/vault/).  This means that apart from setting up Docker, there are no prerequisites for running the integration tests—just running `./gradlew integrationTests` will provision and tear down Vault servers for the tests. 

All tests pass on my environment (OS X 10.10.4, Docker For Mac 1.12).

Note that this patch is not without its downsides:
1. TestContainers requires Java 8.  This is only necessary for running the integration test; I don't know if there is some way to tell Gradle to use Java 7 for everything except the integration test.
2. TestContainers currently doesn't support Docker on Windows. 
