### PR TITLE
Support put method in sys API

### DIFF
--- a/src/main/java/com/bettercloud/vault/api/Sys.java
+++ b/src/main/java/com/bettercloud/vault/api/Sys.java
@@ -1,6 +1,14 @@
 package com.bettercloud.vault.api;
 
 import com.bettercloud.vault.VaultConfig;
+import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.response.SysResponse;
+import com.bettercloud.vault.rest.Rest;
+import com.bettercloud.vault.rest.RestResponse;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * <p>A wrapper around the implementing classes for all of Vault's various
@@ -33,6 +41,57 @@ public class Sys {
      */
     public Debug debug() {
         return new Debug(config);
+    }
+
+    /**
+     * <p>Basic operation to update a status.
+     * E.g.:</p>
+     *
+     * <blockquote>
+     * <pre>{@code
+     * final SysResponse response = vault.sys().put("sys/revoke-prefix/aws");
+     * }</pre>
+     * </blockquote>
+     *
+     * @param path The path of the status which will be updated (e.g. <code>sys/revoke-prefix/aws</code>)
+     * @throws VaultException
+     */
+    public SysResponse put(final String path) throws VaultException {
+        int retryCount = 0;
+        while (true) {
+            try {
+                final RestResponse restResponse = new Rest()//NOPMD
+                        .url(config.getAddress() + "/v1/" + path)
+                        .header("X-Vault-Token", config.getToken())
+                        .connectTimeoutSeconds(config.getOpenTimeout())
+                        .readTimeoutSeconds(config.getReadTimeout())
+                        .sslPemUTF8(config.getSslPemUTF8())
+                        .sslVerification(config.isSslVerify() != null ? config.isSslVerify() : null)
+                        .put();
+
+                System.out.println(restResponse);
+                // Validate response
+                final Set<Integer> validCodes = new HashSet<Integer>(Arrays.asList(204, 429, 500));//NOPMD
+                if (!validCodes.contains(restResponse.getStatus())) {
+                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus());
+                }
+                return new SysResponse(restResponse, retryCount);
+            } catch (Exception e) {
+                // If there are retries to perform, then pause for the configured interval and then execute the loop again...
+                if (retryCount < config.getMaxRetries()) {
+                    retryCount++;
+                    try {
+                        final int retryIntervalMilliseconds = config.getRetryIntervalMilliseconds();
+                        Thread.sleep(retryIntervalMilliseconds);
+                    } catch (InterruptedException e1) {
+                        e1.printStackTrace();
+                    }
+                } else {
+                    // ... otherwise, give up.
+                    throw new VaultException(e);
+                }
+            }
+        }
     }
 
 }

--- a/src/main/java/com/bettercloud/vault/response/SysResponse.java
+++ b/src/main/java/com/bettercloud/vault/response/SysResponse.java
@@ -1,0 +1,39 @@
+package com.bettercloud.vault.response;
+
+import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.rest.RestResponse;
+
+/**
+ * This class is a container for the information returned by Vault in Sys API
+ * operations (e.g. <code>v1/sys/revoke-prefix/aws</code>).
+ */
+public class SysResponse {
+
+    private RestResponse restResponse;
+    private int retries;
+
+    /**
+     * <p>Constructs a <code>SysResponse</code> object from the data received in a put
+     * operation.</p>
+     *
+     * @param restResponse The raw HTTP response from Vault.
+     * @param retries The number of retry attempts that occurred during the API call (can be zero).
+     */
+    public SysResponse(final RestResponse restResponse, final int retries) throws VaultException {
+        this.restResponse = restResponse;
+        this.retries = retries;
+
+        if (restResponse == null || restResponse.getBody() == null) {
+            throw new VaultException("Response is null or contains a bad payload");
+        }
+    }
+
+    public RestResponse getRestResponse() {
+        return restResponse;
+    }
+
+    public int getRetries() {
+        return retries;
+    }
+
+}

--- a/src/test-integration/java/com/bettercloud/vault/api/SysTests.java
+++ b/src/test-integration/java/com/bettercloud/vault/api/SysTests.java
@@ -1,0 +1,52 @@
+package com.bettercloud.vault.api;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.bettercloud.vault.response.SysResponse;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.VaultConfig;
+import com.bettercloud.vault.VaultException;
+
+/**
+ * <p>Integration tests for the basic (i.e. "sys") Vault API operations.</p>
+ *
+ * <p>These tests require a Vault server to be up and running.  See the setup notes in
+ * "src/test-integration/README.md".</p>
+ */
+public class SysTests {
+
+    private static final String address = System.getProperty("VAULT_ADDR");
+    private static final String token = System.getProperty("VAULT_TOKEN");
+
+    private Vault vault;
+
+    @BeforeClass
+    public static void verifyEnv() {
+        assertNotNull(address);
+        assertNotNull(token);
+    }
+
+    @Before
+    public void setup() throws VaultException {
+        final VaultConfig config = new VaultConfig(address, token);
+        vault = new Vault(config);
+    }
+
+    /**
+     * Revoke secrets with a prefix and verify that its response status is 204.
+     *
+     * @throws VaultException
+     */
+    @Test
+    public void testRevokePrefix() throws VaultException {
+        final SysResponse sysResponse = vault.sys().put("sys/revoke-prefix/dummy");
+
+        assertEquals(204, sysResponse.getRestResponse().getStatus());
+    }
+
+}


### PR DESCRIPTION
The logical API call does not support to execute PUT method.

I know that the API supports GET, POST and DELETE methods. (i.e. read, write and delete)
But I want to execute PUT method for the following sys endpoints in Vault HTTP API.

`PUT /sys/revoke/<lease id>`
`PUT /sys/revoke-prefix/<path prefix>`

Could you take a look my implementation?
Please let me know if it needs to be fixed. 😇