### PR TITLE
add support for renewal of leases

### DIFF
--- a/src/main/java/com/bettercloud/vault/api/Leases.java
+++ b/src/main/java/com/bettercloud/vault/api/Leases.java
@@ -2,6 +2,7 @@ package com.bettercloud.vault.api;
 
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.json.Json;
 import com.bettercloud.vault.response.VaultResponse;
 import com.bettercloud.vault.rest.Rest;
 import com.bettercloud.vault.rest.RestResponse;
@@ -185,4 +186,56 @@ public class Leases {
         }
     }
 
+    /**
+     * <p>Renews a given secret lease.</p>
+     *
+     * <blockquote>
+     * <pre>{@code
+     * final VaultResponse response = vault.leases().renew("mongodb/creds/myapp/cd7f9834-b870-9ebc-3da5-27bf9cdc42ad");
+     * assertEquals(200, response.getRestResponse().getStatus());
+     * }</pre>
+     * </blockquote>
+     *
+     * @param leaseId A lease ID associated with a secret
+     * @param increment  A requested amount of time in seconds to extend the lease. This is advisory.
+     * @return The response information returned from Vault
+     * @throws VaultException The response information returned from Vault
+     */
+    public VaultResponse renew(final String leaseId, final long increment) throws VaultException {
+        int retryCount = 0;
+        while (true) {
+                try {
+                        final String requestJson = Json.object().add("increment", increment).toString();
+                        final RestResponse restResponse = new Rest()
+                                        .url(config.getAddress() + "/v1/sys/renew/" + leaseId)
+                                        .header("X-Vault-Token", config.getToken())
+                                        .body(increment < 0 ? null : requestJson.getBytes("UTF-8"))
+                                        .connectTimeoutSeconds(config.getOpenTimeout())
+                                        .readTimeoutSeconds(config.getReadTimeout())
+                                        .sslPemUTF8(config.getSslPemUTF8())
+                                        .sslVerification(config.isSslVerify() != null ? config.isSslVerify() : null)
+                                        .put();
+                        // Validate response
+                        if (restResponse.getStatus() != 200) {
+                                throw new VaultException("Expecting HTTP status 200, but instead receiving " + restResponse.getStatus(), restResponse.getStatus());
+                        }
+                        return new VaultResponse(restResponse, retryCount);
+                } catch (Exception e) {
+                        if (retryCount < config.getMaxRetries()) {
+                                retryCount++;
+                                try {
+                                        final int retryIntervalMilliseconds = config.getRetryIntervalMilliseconds();
+                                        Thread.sleep(retryIntervalMilliseconds);
+                                } catch (InterruptedException e1) {
+                                        e1.printStackTrace();
+                                }
+                        } else if (e instanceof VaultException) {
+                                // ... otherwise, give up.
+                                throw (VaultException) e;
+                        } else {
+                                throw new VaultException(e);
+                        }
+                }
+        }
+    }
 }


### PR DESCRIPTION
This PR adds basic support for renewal of leases, which is necessary to make proper use of dynamic secret backends like the MySQL, PostgreSQL or MongoDB backends.

It currently lacks an integration test.