### PR TITLE
Include response body to exception message

### DIFF
--- a/src/main/java/com/bettercloud/vault/api/Logical.java
+++ b/src/main/java/com/bettercloud/vault/api/Logical.java
@@ -1,5 +1,6 @@
 package com.bettercloud.vault.api;
 
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -61,11 +62,12 @@ public class Logical {
 
                 // Validate response
                 if (restResponse.getStatus() != 200) {
-                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus(), restResponse.getStatus());
+                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus()
+                            + "\nResponse body: " + new String(restResponse.getBody(), "UTF-8"), restResponse.getStatus());
                 }
 
                 return new LogicalResponse(restResponse, retryCount);
-            } catch (RuntimeException | VaultException | RestException e) {
+            } catch (RuntimeException | VaultException | RestException | UnsupportedEncodingException e) {
                 // If there are retries to perform, then pause for the configured interval and then execute the loop again...
                 if (retryCount < config.getMaxRetries()) {
                     retryCount++;
@@ -130,7 +132,8 @@ public class Logical {
                 if (restStatus == 200 || restStatus == 204) {
                     return new LogicalResponse(restResponse, retryCount);
                 } else {
-                    throw new VaultException("Expecting HTTP status 204 or 200, but instead receiving " + restStatus, restStatus);
+                    throw new VaultException("Expecting HTTP status 204 or 200, but instead receiving " + restStatus
+                            + "\nResponse body: " + new String(restResponse.getBody(), "UTF-8"), restStatus);
                 }
             } catch (Exception e) {
                 // If there are retries to perform, then pause for the configured interval and then execute the loop again...
@@ -218,10 +221,11 @@ public class Logical {
 
                 // Validate response
                 if (restResponse.getStatus() != 204) {
-                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus(), restResponse.getStatus());
+                    throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus()
+                            + "\nResponse body: " + new String(restResponse.getBody(), "UTF-8"), restResponse.getStatus());
                 }
                 return new LogicalResponse(restResponse, retryCount);
-            } catch (RuntimeException | VaultException | RestException e) {
+            } catch (RuntimeException | VaultException | RestException | UnsupportedEncodingException e) {
                 // If there are retries to perform, then pause for the configured interval and then execute the loop again...
                 if (retryCount < config.getMaxRetries()) {
                     retryCount++;

--- a/src/main/java/com/bettercloud/vault/rest/Rest.java
+++ b/src/main/java/com/bettercloud/vault/rest/Rest.java
@@ -512,10 +512,23 @@ public class Rest {
      *
      * @param connection An active HTTP(S) connection
      * @return The body payload, downloaded from the HTTP connection response
+     * @throws RestException
      */
-    private byte[] responseBodyBytes(final URLConnection connection) {
+    private byte[] responseBodyBytes(final URLConnection connection) throws RestException {
         try {
-            final InputStream inputStream = connection.getInputStream();
+            final InputStream inputStream;
+            final int responseCode = this.connectionStatus(connection);
+            if (200 <= responseCode && responseCode  <= 299) {
+                inputStream = connection.getInputStream();
+            } else {
+                if (connection instanceof HttpsURLConnection) {
+                    final HttpsURLConnection httpsURLConnection = (HttpsURLConnection) connection;
+                    inputStream = httpsURLConnection.getErrorStream();
+                } else {
+                    final HttpURLConnection httpURLConnection = (HttpURLConnection) connection;
+                    inputStream = httpURLConnection.getErrorStream();
+                }
+            }
             final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
             int bytesRead;
             final byte[] bytes = new byte[16384];

--- a/src/test-integration/java/com/bettercloud/vault/api/LogicalTests.java
+++ b/src/test-integration/java/com/bettercloud/vault/api/LogicalTests.java
@@ -6,11 +6,13 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
+import org.junit.rules.ExpectedException;
 
 import static junit.framework.TestCase.*;
 
@@ -134,6 +136,85 @@ public class LogicalTests {
         assertTrue(vault.logical().list("secret").contains("hello"));
         vault.logical().delete("secret/hello");
         assertFalse(vault.logical().list("secret").contains("hello"));
+    }
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    /**
+     * Tests that exception message includes errors returned by Vault
+     *
+     * @throws VaultException
+     */
+    @Test
+    public void testReadExceptionMessageIncludesErrorsReturnedByVault() throws VaultException {
+        expectedEx.expect(VaultException.class);
+        expectedEx.expectMessage("permission denied");
+
+        final VaultConfig config = new VaultConfig(address, "invalid-token");
+        final Vault vault = new Vault(config);
+        vault.logical().read("secret/null");
+    }
+
+    /**
+     * Tests that exception message includes errors returned by Vault
+     *
+     * @throws VaultException
+     */
+    @Test
+    public void testWriteExceptionMessageIncludesErrorsReturnedByVault() throws VaultException {
+        expectedEx.expect(VaultException.class);
+        expectedEx.expectMessage("permission denied");
+
+        final VaultConfig config = new VaultConfig(address, "invalid-token");
+        final Vault vault = new Vault(config);
+        vault.logical().write("secret/null", new HashMap<String, String>() {{ put("value", null); }});
+    }
+
+    /**
+     * Tests that exception message includes errors returned by Vault
+     *
+     * @throws VaultException
+     */
+    @Test
+    public void testDeleteExceptionMessageIncludesErrorsReturnedByVault() throws VaultException {
+        expectedEx.expect(VaultException.class);
+        expectedEx.expectMessage("permission denied");
+
+        final VaultConfig config = new VaultConfig(address, "invalid-token");
+        final Vault vault = new Vault(config);
+        vault.logical().delete("secret/null");
+    }
+
+    /**
+     * Tests that exception message includes errors returned by Vault
+     *
+     * @throws VaultException
+     */
+    @Test
+    public void testListExceptionMessageIncludesErrorsReturnedByVault() throws VaultException {
+        expectedEx.expect(VaultException.class);
+        expectedEx.expectMessage("permission denied");
+
+        final VaultConfig config = new VaultConfig(address, "invalid-token");
+        final Vault vault = new Vault(config);
+        vault.logical().list("secret/null");
+    }
+
+    /**
+     * Write a secret and verify that it can be read containing a null value.
+     *
+     * @throws VaultException
+     */
+    @Test
+    public void testReadExceptionMessageIncludesErrorsReturnedByVaultOn404() throws VaultException {
+        expectedEx.expect(VaultException.class);
+        expectedEx.expectMessage("{\"errors\":[]}");
+
+        final VaultConfig config = new VaultConfig(address, token);
+        final Vault vault = new Vault(config);
+
+        vault.logical().read("secret/null");
     }
 
 }

--- a/src/test/java/com/bettercloud/vault/rest/GetTests.java
+++ b/src/test/java/com/bettercloud/vault/rest/GetTests.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import java.io.UnsupportedEncodingException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests relating the REST client processing of GET requests.
@@ -129,6 +130,24 @@ public class GetTests {
         assertEquals("white", headers.getString("Black", null));
         assertEquals("night", headers.getString("Day", null));
         assertEquals("Note+that+headers+are+send+in+url-encoded+format", headers.getString("Two-Part", null));
+    }
+
+    /**
+     * <p>Verify that response body is retrieved when http status is error code</p>
+     *
+     * @throws RestException
+     * @throws UnsupportedEncodingException If there's a problem parsing the response JSON as UTF-8
+     */
+    @Test
+    public void testGet_RetrievesResponseBodyWhenStatusIs418() throws RestException, UnsupportedEncodingException {
+        final RestResponse restResponse = new Rest()
+                .url("http://httpbin.org/status/418")
+                .get();
+        assertEquals(418, restResponse.getStatus());
+
+        final String responseBody = new String(restResponse.getBody(), "UTF-8");
+        assertTrue("Response body is empty", responseBody.length() > 0);
+        assertTrue("Response body doesn't contain word teapot", responseBody.contains("teapot"));
     }
 
 }


### PR DESCRIPTION
Status code isn't sufficient to understand the error in some cases,
so I made this patch to include response body to exception message.

Examples of exception message:
```
com.bettercloud.vault.VaultException: Expecting HTTP status 204 or 200, but instead receiving 403
Response body: {"errors":["permission denied"]}
```
```
Vault responded with HTTP status code: 404
Response body: {"errors":[]}
```
Closes #47 

