### PR TITLE
Add LookupSelf capability to Auth

### DIFF
--- a/src/main/java/com/bettercloud/vault/api/Auth.java
+++ b/src/main/java/com/bettercloud/vault/api/Auth.java
@@ -462,8 +462,8 @@ public class Auth {
                 if (restResponse.getStatus() != 200) {
                     throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus(), restResponse.getStatus());
                 }
-                final String mimeType = restResponse.getMimeType() == null ? "null" : restResponse.getMimeType();
-                if (!mimeType.equals("application/json")) {
+                final String mimeType = restResponse.getMimeType();
+                if (mimeType == null || !"application/json".equals(mimeType)) {
                     throw new VaultException("Vault responded with MIME type: " + mimeType, restResponse.getStatus());
                 }
                 return new LookupResponse(restResponse, retryCount);
@@ -475,9 +475,9 @@ public class Auth {
                         final int retryIntervalMilliseconds = config.getRetryIntervalMilliseconds();
                         Thread.sleep(retryIntervalMilliseconds);
                     } catch (InterruptedException e1) {
-                        e1.printStackTrace();
+                        e1.printStackTrace(); //NOPMD
                     }
-                } else if (e instanceof VaultException) {
+                } else if (e instanceof VaultException) { //NOPMD
                     // ... otherwise, give up.
                     throw (VaultException) e;
                 } else {

--- a/src/main/java/com/bettercloud/vault/response/LookupResponse.java
+++ b/src/main/java/com/bettercloud/vault/response/LookupResponse.java
@@ -1,0 +1,128 @@
+package com.bettercloud.vault.response;
+
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.bettercloud.vault.json.*;
+import com.bettercloud.vault.rest.RestResponse;
+
+/**
+ * This class is a container for the information returned by Vault in lookup operations on auth backends.
+ */
+public class LookupResponse extends VaultResponse {
+
+    private String accessor;
+    private long creationTime;
+    private long creationTTL;
+    private String displayName;
+    private long explicitMaxTTL;
+    private String id;
+    private Long lastRenewalTime;
+    private int numUses;
+    private boolean orphan;
+    private String path;
+    private List<String> policies;
+    private boolean renewable;
+    private long ttl;
+    private String username;
+
+    /**
+     * This constructor simply exposes the common base class constructor.
+     *
+     * @param restResponse The raw HTTP response from Vault.
+     * @param retries      The number of retry attempts that occurred during the API call (can be zero).
+     */
+    public LookupResponse(final RestResponse restResponse, final int retries) {
+        super(restResponse, retries);
+
+        try {
+            final String responseJson = new String(restResponse.getBody(), "UTF-8");
+            final JsonObject jsonObject = Json.parse(responseJson).asObject();
+            final JsonObject dataJsonObject = jsonObject.get("data").asObject();
+
+            accessor = dataJsonObject.getString("accessor", "");
+            creationTime = dataJsonObject.getLong("creation_time", 0);
+            creationTTL = dataJsonObject.getLong("creation_ttl", 0);
+            displayName = dataJsonObject.getString("display_name", "");
+            explicitMaxTTL = dataJsonObject.getLong("explicit_max_ttl", 0);
+            id = dataJsonObject.getString("id", "");
+            final JsonValue lastRenewalTimeJsonValue = dataJsonObject.get("last_renewal_time");
+            if (lastRenewalTimeJsonValue != null) {
+                lastRenewalTime = lastRenewalTimeJsonValue.asLong();
+            }
+            if (dataJsonObject.get("metadata") != null && !dataJsonObject.get("metadata").toString().equalsIgnoreCase("null")) {
+                final JsonObject metadata = dataJsonObject.get("metadata").asObject();
+                username = metadata.getString("username", "");
+            }
+            numUses = dataJsonObject.getInt("num_uses", 0);
+            orphan = dataJsonObject.getBoolean("orphan", true);
+            path = dataJsonObject.getString("path", "");
+            final JsonArray policiesJsonArray = dataJsonObject.get("policies").asArray();
+            policies = new ArrayList<>();
+            for (final JsonValue policy : policiesJsonArray) {
+                policies.add(policy.asString());
+            }
+            renewable = dataJsonObject.getBoolean("renewable", false);
+            ttl = dataJsonObject.getLong("ttl", 0);
+
+        } catch (UnsupportedEncodingException | ParseException e) {
+        }
+    }
+
+    public String getAccessor() {
+        return accessor;
+    }
+
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    public long getCreationTTL() {
+        return creationTTL;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public long getExplicitMaxTTL() {
+        return explicitMaxTTL;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Long getLastRenewalTime() {
+        return lastRenewalTime;
+    }
+
+    public int getNumUses() {
+        return numUses;
+    }
+
+    public boolean isOrphan() {
+        return orphan;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public List<String> getPolicies() {
+        return policies;
+    }
+
+    public boolean isRenewable() {
+        return renewable;
+    }
+
+    public long getTTL() {
+        return ttl;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/test-integration/java/com/bettercloud/vault/api/AuthTests.java
+++ b/src/test-integration/java/com/bettercloud/vault/api/AuthTests.java
@@ -11,6 +11,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.UnsupportedEncodingException;
+import java.util.List;
 
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.assertEquals;
@@ -173,6 +174,6 @@ public class AuthTests {
         final LookupResponse lookupResponse = lookupVault.auth().lookupSelf();
         assertEquals(token, lookupResponse.getId());
         assertEquals(3600, lookupResponse.getCreationTTL());
-        assertTrue(lookupResponse.getCreationTTL()<=3600);
+        assertTrue(lookupResponse.getTTL()<=3600);
     }
 }

--- a/src/test-integration/java/com/bettercloud/vault/api/AuthTests.java
+++ b/src/test-integration/java/com/bettercloud/vault/api/AuthTests.java
@@ -6,11 +6,13 @@ import com.bettercloud.vault.VaultException;
 import com.bettercloud.vault.json.Json;
 import com.bettercloud.vault.response.AuthResponse;
 import com.bettercloud.vault.response.LogicalResponse;
+import com.bettercloud.vault.response.LookupResponse;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.UnsupportedEncodingException;
 
+import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertNotSame;
@@ -150,4 +152,27 @@ public class AuthTests {
         assertEquals(20, explicitLeaseDuration);
     }
 
+    /**
+     * Tests token lookup-self for the token auth backend.
+     *
+     * @throws VaultException
+     */
+    @Test
+    public void testLookupSelf() throws VaultException, UnsupportedEncodingException {
+        // Generate a client token
+        final VaultConfig authConfig = new VaultConfig(address, rootToken);
+        final Vault authVault = new Vault(authConfig);
+        final AuthResponse createResponse = authVault.auth().createToken(null, null, null, null, null, "1h", null, null);
+        final String token = createResponse.getAuthClientToken();
+        assertNotNull(token);
+        assertNotSame("", token.trim());
+
+        // Lookup the client token
+        final VaultConfig lookupConfig = new VaultConfig(address, token);
+        final Vault lookupVault = new Vault(lookupConfig);
+        final LookupResponse lookupResponse = lookupVault.auth().lookupSelf();
+        assertEquals(token, lookupResponse.getId());
+        assertEquals(3600, lookupResponse.getCreationTTL());
+        assertTrue(lookupResponse.getCreationTTL()<=3600);
+    }
 }


### PR DESCRIPTION
Under some circumstances, it's necessary to lookup a token to ensure that it is still valid.

Currently the library does not have any facility to do this.

I have created a separate response as it is significantly different to the other Auth responses, particular in the use of "data" as opposed to "auth" in the response.