### PR TITLE
Fix incorrect method call on lookup-self

### DIFF
--- a/src/main/java/com/bettercloud/vault/api/Auth.java
+++ b/src/main/java/com/bettercloud/vault/api/Auth.java
@@ -681,7 +681,7 @@ public class Auth {
                         .readTimeoutSeconds(config.getReadTimeout())
                         .sslPemUTF8(config.getSslPemUTF8())
                         .sslVerification(config.isSslVerify())
-                        .post();
+                        .get();
                 // Validate restResponse
                 if (restResponse.getStatus() != 200) {
                     throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus(), restResponse.getStatus());

--- a/src/test-integration/java/com/bettercloud/vault/api/LogicalTests.java
+++ b/src/test-integration/java/com/bettercloud/vault/api/LogicalTests.java
@@ -169,7 +169,7 @@ public class LogicalTests {
 
         final VaultConfig config = new VaultConfig(address, "invalid-token");
         final Vault vault = new Vault(config);
-        vault.logical().write("secret/null", new HashMap<String, String>() {{ put("value", null); }});
+        vault.logical().write("secret/null", new HashMap<String, Object>() {{ put("value", null); }});
     }
 
     /**
@@ -216,6 +216,7 @@ public class LogicalTests {
         final Vault vault = new Vault(config);
 
         vault.logical().read("secret/null");
+    }
 
     @Test
     public void testWriteAndRead_allDataTypes() throws VaultException {


### PR DESCRIPTION
Apologies for the incorrect method call on lookup-self. I only realised it was wrong when I ran my own integration test and it failed.

I was surprised that your integration test didn't pick it up, and I can't quite figure out why. Perhaps it's something to do with being a dev server.

In any case, our integration test runs against a docker-vault instance and it passes.

Also fixed a compile error in LogicalTests which looks like it got merged in with some other changes yesterday.