### PR TITLE
Removes an out-of-date note in the documentation.

### DIFF
--- a/src/main/java/com/bettercloud/vault/response/VaultResponse.java
+++ b/src/main/java/com/bettercloud/vault/response/VaultResponse.java
@@ -10,11 +10,6 @@ import java.io.Serializable;
  * responses (e.g. the raw HTTP response, the number of retry attempts if any).  API methods
  * which return additional information will use more specialized subclasses inheriting
  * from <code>VaultResponse</code>.</p>
- *
- * <p>NOTE: It turns out that not all API methods will populate <code>leaseId</code>,
- * <code>renewable</code>, and <code>leaseDuration</code>.  In fact, many response types won't.
- * So the next major release will implement those fields directly in the subclasses where they're
- * used.
  */
 public class VaultResponse implements Serializable {
 


### PR DESCRIPTION
This note is out of date; it references code that was removed [in this commit](https://github.com/BetterCloud/vault-java-driver/commit/79da0c4682aed98075696ce1ad346330222ddd19#diff-79a48df50b6d012ba0a90a52ef0ba22d). Very minor change, but the documentation confused me for a sec, so figured I'd fix it.

Thanks for creating this client!