### PR TITLE
Normalize the address for VaultConfig for consistent pathing downstream.

### DIFF
--- a/src/main/java/com/bettercloud/vault/VaultConfig.java
+++ b/src/main/java/com/bettercloud/vault/VaultConfig.java
@@ -73,7 +73,10 @@ public class VaultConfig implements Serializable {
      * @return This object, with address populated, ready for additional builder-pattern method calls or else finalization with the build() method
      */
     public VaultConfig address(final String address) {
-        this.address = address;
+        this.address = address.trim();
+        if (this.address.endsWith("/")) {
+            this.address = this.address.substring(0, this.address.length() - 1);
+        }
         return this;
     }
 

--- a/src/test/java/com/bettercloud/vault/VaultConfigTests.java
+++ b/src/test/java/com/bettercloud/vault/VaultConfigTests.java
@@ -94,6 +94,18 @@ public class VaultConfigTests {
     }
 
     /**
+     * Test creating a new <code>VaultConfig</code> via its constructor, ensuring that addresses are normalized to
+     * not have a trailing slash.
+     *
+     * @throws VaultException
+     */
+    @Test
+    public void testConfigConstructor_NormalizesAddress() throws VaultException {
+        final VaultConfig config = new VaultConfig().address("https://localhost:8200/").build();
+        assertEquals("https://localhost:8200", config.getAddress());
+    }
+
+    /**
      * Test creating a new <code>VaultConfig</code> via its constructor, passing null address and token values AND
      * having them unavailable in the environment variables too.  This should cause initialization failure.
      *


### PR DESCRIPTION
This was a by-product of chasing down a bug having to do with tokens. I had configured my testing to point to "https://localhost:8200/" (with trailing slash). This was causing a POST request to "https://localhost:8200//v1/transit/keys/my-key" (note the extra slash) to receive a 302 to "https://localhost:8200/v1/transit/keys/my-key" (slash removed).

My problem went away just by changing my configuration to not contain the trailing slash, but the underlying cause is deep in the bowels of HttpUrlConnection, which isn't propagating the X-Vault-Token header when it redirects, and then getting an error message about missing token returned in a 400 from Vault.