### PR TITLE
Made secretsEnginePathMap public

### DIFF
--- a/src/main/java/com/bettercloud/vault/VaultConfig.java
+++ b/src/main/java/com/bettercloud/vault/VaultConfig.java
@@ -151,8 +151,21 @@ public class VaultConfig implements Serializable {
      *                             "/secret/bar", "2"
      * @return This object, with secrets paths populated, ready for additional builder-pattern method calls or else finalization with the build() method
      */
-    VaultConfig secretsEnginePathMap(final Map<String, String> secretEngineVersions) {
-        this.secretsEnginePathMap = secretEngineVersions;
+    public VaultConfig secretsEnginePathMap(final Map<String, String> secretEngineVersions) {
+        this.secretsEnginePathMap = new ConcurrentHashMap<>(secretEngineVersions);
+        return this;
+    }
+    
+    /**
+     * <p>Sets the secrets Engine version be used by Vault for the provided path.</p>
+     *
+     * @param path the path to use for accessing Vault secrets.
+     *             Example "/secret/foo" 
+     * @return This object, with a new entry in the secrets paths map, ready for additional builder-pattern method calls or else finalization with 
+     *         the build() method
+     */
+    public VaultConfig putSecretsEngineVersionForPath(String path, String version) {
+        this.secretsEnginePathMap.put(path, version);
         return this;
     }
 


### PR DESCRIPTION
1. Made `secretsEnginePathMap` public
2. Copying the map provided to `secretsEnginePathMap` - making it `ConcurrentHashMap` for consistency, though builders are usually modified within a single thread, so a concurrent hash map is not really necessary.
3. Added convenience method `putSecretsEngineVersionForPath` for adding a single entry to the map

Also consider switching to https://immutables.github.io/ for builders - takes a lot of boiler-plate away and offers a lot of useful helper methods by default