### PR TITLE
Support for auth within Kubernetes and generic JWT

### DIFF
--- a/src/main/java/com/bettercloud/vault/api/Auth.java
+++ b/src/main/java/com/bettercloud/vault/api/Auth.java
@@ -982,7 +982,7 @@ public class Auth {
      * @return The auth token, with additional response metadata
      * @throws VaultException If any error occurs, or unexpected response received from Vault
      */
-    private AuthResponse loginByKubernetes(final String role, final String jwt) throws VaultException {
+    public AuthResponse loginByKubernetes(final String role, final String jwt) throws VaultException {
         return loginByJwt("kubernetes", role, jwt);
     }
 

--- a/src/main/java/com/bettercloud/vault/api/Auth.java
+++ b/src/main/java/com/bettercloud/vault/api/Auth.java
@@ -879,23 +879,24 @@ public class Auth {
     }
 
     /**
-     * <p>Basic login operation to authenticate to an GCP backend.  Example usage:</p>
+     * <p>Basic login operation to authenticate to an JWT backend.  Example usage:</p>
      *
      * <blockquote>
      * <pre>{@code
-     * final AuthResponse response = vault.auth().loginByGCP("dev", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...");
+     * final AuthResponse response = vault.auth().loginByJwt("kubernetes", "dev", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...");
      *
      * final String token = response.getAuthClientToken();
      * }</pre>
      * </blockquote>
      *
+     * @param provider Provider of JWT token.
      * @param role The gcp role used for authentication
      * @param jwt  The JWT token for the role
      * @return The auth token, with additional response metadata
      * @throws VaultException If any error occurs, or unexpected response received from Vault
      */
     // TODO: Needs integration test coverage if possible
-    public AuthResponse loginByGCP(final String role, final String jwt) throws VaultException {
+    public AuthResponse loginByJwt(final String provider, final String role, final String jwt) throws VaultException {
         int retryCount = 0;
 
         while (true) {
@@ -903,7 +904,7 @@ public class Auth {
                 // HTTP request to Vault
                 final String requestJson = Json.object().add("role", role).add("jwt", jwt).toString();
                 final RestResponse restResponse = new Rest()
-                        .url(config.getAddress() + "/v1/auth/gcp/login")
+                        .url(config.getAddress() + "/v1/auth/" + provider + "/login")
                         .optionalHeader("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -939,6 +940,50 @@ public class Auth {
                 }
             }
         }
+    }
+
+
+    /**
+     * <p>Basic login operation to authenticate to an GCP backend.  Example usage:</p>
+     *
+     * <blockquote>
+     * <pre>{@code
+     * final AuthResponse response = vault.auth().loginByGCP("dev", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...");
+     *
+     * final String token = response.getAuthClientToken();
+     * }</pre>
+     * </blockquote>
+     *
+     * @param role The gcp role used for authentication
+     * @param jwt  The JWT token for the role
+     * @return The auth token, with additional response metadata
+     * @throws VaultException If any error occurs, or unexpected response received from Vault
+     */
+    public AuthResponse loginByGCP(final String role, final String jwt) throws VaultException {
+        return loginByJwt("gcp", role, jwt);
+    }
+
+
+    /**
+     * Basic login operation to authenticate to an kubernetes backend. Example usage:
+     *
+     * <blockquote>
+     *
+     * <pre>{@code
+     * final AuthResponse response =
+     *     vault.auth().loginByKubernetes("dev", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...");
+     *
+     * final String token = response.getAuthClientToken();
+     * }</pre>
+     * </blockquote>
+     *
+     * @param role The kubernetes role used for authentication
+     * @param jwt The JWT token for the role, typically read from /var/run/secrets/kubernetes.io/serviceaccount/token
+     * @return The auth token, with additional response metadata
+     * @throws VaultException If any error occurs, or unexpected response received from Vault
+     */
+    private AuthResponse loginByKubernetes(final String role, final String jwt) throws VaultException {
+        return loginByJwt("kubernetes", role, jwt);
     }
 
     /**


### PR DESCRIPTION
Support using JWT token for Kubernetes service account to
authenticate. Since both GCP and Kubernetes uses JWT, refactored to
also offer generic JWT support to be used by aginst other JWT
based authentication services.