### PR TITLE
Drop lombok & jaxb dependencies & package module-info for JDK9+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,24 @@ compileJava {
     targetCompatibility = 1.8
 }
 
+sourceSets {
+    main {
+        java {
+            exclude 'module-info.java'
+        }
+    }
+    mainModuleInfo {
+        java {
+            srcDirs = ['src/main/java']
+            outputDir = file("$buildDir/classes/java/main")
+            include 'module-info.java'
+        }
+    }
+}
+
+classes.dependsOn mainModuleInfoClasses
+compileMainModuleInfoJava.options.compilerArgs.addAll(['--release', '9'])
+
 compileTestJava {
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
@@ -22,8 +40,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly('org.projectlombok:lombok:1.18.4')
-
     testCompile('junit:junit:4.12')
     testCompile('org.mockito:mockito-core:2.23.4')
     testCompile('org.testcontainers:testcontainers:1.6.0')

--- a/src/main/java/com/bettercloud/vault/SslConfig.java
+++ b/src/main/java/com/bettercloud/vault/SslConfig.java
@@ -1,15 +1,12 @@
 package com.bettercloud.vault;
 
 import com.bettercloud.vault.api.Auth;
-import lombok.AccessLevel;
-import lombok.Getter;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
-import javax.xml.bind.DatatypeConverter;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -33,6 +30,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
 
 /**
  * <p>A container for SSL-related configuration options, meant to be stored within a {@link VaultConfig} instance.</p>
@@ -47,12 +45,12 @@ public class SslConfig implements Serializable {
     private static final String VAULT_SSL_VERIFY = "VAULT_SSL_VERIFY";
     private static final String VAULT_SSL_CERT = "VAULT_SSL_CERT";
 
-    @Getter private boolean verify;
-    @Getter private transient SSLContext sslContext;
+    private boolean verify;
+    private transient SSLContext sslContext;
     private transient KeyStore trustStore;
     private transient KeyStore keyStore;
     private String keyStorePassword;
-    @Getter(AccessLevel.PROTECTED) private String pemUTF8;  // exposed to unit tests
+    private String pemUTF8;  // exposed to unit tests
     private String clientPemUTF8;
     private String clientKeyPemUTF8;
     private Boolean verifyObject;
@@ -464,6 +462,18 @@ public class SslConfig implements Serializable {
         return this;
     }
 
+    public boolean isVerify() {
+        return verify;
+    }
+
+    public SSLContext getSslContext() {
+        return sslContext;
+    }
+
+    protected String getPemUTF8() {
+        return pemUTF8;
+    }
+
     /**
      * <p>Constructs the {@link this#sslContext} member field, if SSL verification is enabled and any JKS or PEM-based
      * data was populated.  This method is broken off from {@link this#build()}, because the same process must
@@ -561,7 +571,7 @@ public class SslConfig implements Serializable {
                 // Convert the client private key into a PrivateKey
                 final String strippedKey = clientKeyPemUTF8.replace("-----BEGIN PRIVATE KEY-----", "")
                                                      .replace("-----END PRIVATE KEY-----", "");
-                final byte[] keyBytes = DatatypeConverter.parseBase64Binary(strippedKey);
+                final byte[] keyBytes = Base64.getDecoder().decode(strippedKey);
                 final PKCS8EncodedKeySpec pkcs8EncodedKeySpec = new PKCS8EncodedKeySpec(keyBytes);
                 final KeyFactory factory = KeyFactory.getInstance("RSA");
                 final PrivateKey privateKey = factory.generatePrivate(pkcs8EncodedKeySpec);

--- a/src/main/java/com/bettercloud/vault/VaultConfig.java
+++ b/src/main/java/com/bettercloud/vault/VaultConfig.java
@@ -1,7 +1,5 @@
 package com.bettercloud.vault;
 
-import lombok.Getter;
-
 import java.io.Serializable;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,25 +30,15 @@ public class VaultConfig implements Serializable {
     private static final String VAULT_OPEN_TIMEOUT = "VAULT_OPEN_TIMEOUT";
     private static final String VAULT_READ_TIMEOUT = "VAULT_READ_TIMEOUT";
 
-    @Getter
     private Map<String, String> secretsEnginePathMap = new ConcurrentHashMap<>();
-    @Getter
     private String address;
-    @Getter
     private String token;
-    @Getter
     private SslConfig sslConfig;
-    @Getter
     private Integer openTimeout;
-    @Getter
     private Integer readTimeout;
-    @Getter
     private int maxRetries;
-    @Getter
     private int retryIntervalMilliseconds;
-    @Getter
     private Integer globalEngineVersion;
-    @Getter
     private String nameSpace;
     private EnvironmentLoader environmentLoader;
 
@@ -283,6 +271,46 @@ public class VaultConfig implements Serializable {
             this.sslConfig = new SslConfig().environmentLoader(this.environmentLoader).build();
         }
         return this;
+    }
+
+    public Map<String, String> getSecretsEnginePathMap() {
+        return secretsEnginePathMap;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public SslConfig getSslConfig() {
+        return sslConfig;
+    }
+
+    public Integer getOpenTimeout() {
+        return openTimeout;
+    }
+
+    public Integer getReadTimeout() {
+        return readTimeout;
+    }
+
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    public int getRetryIntervalMilliseconds() {
+        return retryIntervalMilliseconds;
+    }
+
+    public Integer getGlobalEngineVersion() {
+        return globalEngineVersion;
+    }
+
+    public String getNameSpace() {
+        return nameSpace;
     }
 
 }

--- a/src/main/java/com/bettercloud/vault/api/Auth.java
+++ b/src/main/java/com/bettercloud/vault/api/Auth.java
@@ -10,7 +10,6 @@ import com.bettercloud.vault.response.LogicalResponse;
 import com.bettercloud.vault.response.LookupResponse;
 import com.bettercloud.vault.rest.Rest;
 import com.bettercloud.vault.rest.RestResponse;
-import lombok.Getter;
 
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
@@ -40,23 +39,14 @@ public class Auth {
      */
     public static class TokenRequest implements Serializable {
 
-        @Getter
         private UUID id;
-        @Getter
         private List<String> polices;
-        @Getter
         private Map<String, String> meta;
-        @Getter
         private Boolean noParent;
-        @Getter
         private Boolean noDefaultPolicy;
-        @Getter
         private String ttl;
-        @Getter
         private String displayName;
-        @Getter
         private Long numUses;
-        @Getter
         private String role;
 
         /**
@@ -138,6 +128,42 @@ public class Auth {
         public TokenRequest role(final String role) {
             this.role = role;
             return this;
+        }
+
+        public UUID getId() {
+            return id;
+        }
+
+        public List<String> getPolices() {
+            return polices;
+        }
+
+        public Map<String, String> getMeta() {
+            return meta;
+        }
+
+        public Boolean getNoParent() {
+            return noParent;
+        }
+
+        public Boolean getNoDefaultPolicy() {
+            return noDefaultPolicy;
+        }
+
+        public String getTtl() {
+            return ttl;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        public Long getNumUses() {
+            return numUses;
+        }
+
+        public String getRole() {
+            return role;
         }
     }
 

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module vault.java.driver {
+    exports com.bettercloud.vault;
+    exports com.bettercloud.vault.api;
+    exports com.bettercloud.vault.json;
+    exports com.bettercloud.vault.response;
+    exports com.bettercloud.vault.rest;
+}


### PR DESCRIPTION
Hi, and thanks a lot for the driver!

I'm working on moving an application to JDK9+ and in particular I'm interested in generating jlink images. With a view to this I've created the following pull request that:

- adds a module-info.class compiled with JDK9 while leaving all other sources as JDK8. This should ensure compatibility when running on either JDK version.
- replaces the dependency on javax.xml.bind.DatatypeConverter (removed in JDK11) with the java.util.Base64 class added in JDK8. (zero-dependency!)
- potentially controversially, removes the compile dependency on lombok. (it caused me all kinds of trouble during this exercise, but that may be my own failing)

Let me know if you think this would be useful!