### PR TITLE
Add nonce value to AuthResponse

### DIFF
--- a/src/main/java/com/bettercloud/vault/response/AuthResponse.java
+++ b/src/main/java/com/bettercloud/vault/response/AuthResponse.java
@@ -24,6 +24,7 @@ public class AuthResponse extends VaultResponse {
     private String appId;
     private String userId;
     private String username;
+    private String nonce;
 
     /**
      * This constructor simply exposes the common base class constructor.
@@ -47,6 +48,7 @@ public class AuthResponse extends VaultResponse {
                 appId = metadata.getString("app-id", "");
                 userId = metadata.getString("user-id", "");
                 username = metadata.getString("username", "");
+                nonce = metadata.getString("nonce", "");
             }
             authClientToken = authJsonObject.getString("client_token", "");
             final JsonArray authPoliciesJsonArray = authJsonObject.get("policies").asArray();
@@ -89,4 +91,6 @@ public class AuthResponse extends VaultResponse {
     public String getUserId() {
         return userId;
     }
+
+    public String getNonce() { return nonce; }
 }

--- a/src/test/java/com/bettercloud/vault/vault/api/AuthBackendAwsTests.java
+++ b/src/test/java/com/bettercloud/vault/vault/api/AuthBackendAwsTests.java
@@ -4,6 +4,7 @@ import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
 import com.bettercloud.vault.json.JsonObject;
+import com.bettercloud.vault.response.AuthResponse;
 import com.bettercloud.vault.vault.VaultTestUtils;
 import com.bettercloud.vault.vault.mock.AuthRequestValidatingMockVault;
 import org.eclipse.jetty.server.Server;
@@ -41,15 +42,19 @@ public class AuthBackendAwsTests {
         final Vault vault = new Vault(vaultConfig);
 
         String token = null;
+        String nonce = null;
         try {
-            token = vault.auth()
-                    .loginByAwsEc2("role", "identity", "signature", null, null)
-                    .getAuthClientToken();
+            AuthResponse response = vault.auth()
+                    .loginByAwsEc2("role", "identity", "signature", null, null);
+            nonce = response.getNonce();
+            token = response.getAuthClientToken();
         } catch (VaultException ignored) {
         }
 
         server.stop();
 
+        assertNotNull(nonce);
+        assertEquals("5defbf9e-a8f9-3063-bdfc-54b7a42a1f95", nonce.trim());
         assertNotNull(token);
         assertEquals("c9368254-3f21-aded-8a6f-7c818e81b17a", token.trim());
 
@@ -80,15 +85,18 @@ public class AuthBackendAwsTests {
         System.out.println("Running Aws EC2 test");
 
         String token = null;
+        String nonce = null;
         try {
-            token = vault.auth()
-                    .loginByAwsEc2("role", "pkcs7", null, null)
-                    .getAuthClientToken();
+            AuthResponse response = vault.auth().loginByAwsEc2("role", "pkcs7", null, null);
+            nonce = response.getNonce();
+            token = response.getAuthClientToken();
         } catch (VaultException ignored) {
         }
 
         server.stop();
 
+        assertNotNull(nonce);
+        assertEquals("5defbf9e-a8f9-3063-bdfc-54b7a42a1f95", nonce.trim());
         assertNotNull(token);
         assertEquals("c9368254-3f21-aded-8a6f-7c818e81b17a", token.trim());
     }
@@ -114,13 +122,16 @@ public class AuthBackendAwsTests {
                 .build();
         final Vault vault = new Vault(vaultConfig);
 
-        final String token = vault.auth()
+        AuthResponse response = vault.auth()
                 .loginByAwsIam("role", "url", "body", "headers",
-                        null)
-                .getAuthClientToken();
+                        null);
+        final String nonce = response.getNonce();
+        final String token = response.getAuthClientToken();
 
         server.stop();
 
+        assertNotNull(nonce);
+        assertEquals("5defbf9e-a8f9-3063-bdfc-54b7a42a1f95", nonce.trim());
         assertNotNull(token);
         assertEquals("c9368254-3f21-aded-8a6f-7c818e81b17a", token.trim());
     }

--- a/src/test/java/com/bettercloud/vault/vault/mock/AuthRequestValidatingMockVault.java
+++ b/src/test/java/com/bettercloud/vault/vault/mock/AuthRequestValidatingMockVault.java
@@ -19,7 +19,8 @@ public class AuthRequestValidatingMockVault extends MockVault {
             "      \"instance_id\": \"i-de0f1344\",\n" +
             "      \"ami_id\": \"ami-fce36983\",\n" +
             "      \"role\": \"dev-role\",\n" +
-            "      \"auth_type\": \"ec2\"\n" +
+            "      \"auth_type\": \"ec2\",\n" +
+            "      \"nonce\": \"5defbf9e-a8f9-3063-bdfc-54b7a42a1f95\"\n" +
             "    },\n" +
             "    \"policies\": [\n" +
             "      \"default\",\n" +


### PR DESCRIPTION
In order to re-authenticate with Vault via AWS, the nonce from the original authentication request needs to be used. The nonce value was not included in AuthResponse; I added it so it can be retrieved to be used in future authentication requests.

Per the vault [documentation](https://www.vaultproject.io/docs/auth/aws.html), this is the response from AWS authentication:
`{
  "auth": {
    "renewable": true,
    "lease_duration": 72000,
    "metadata": {
      "role_tag_max_ttl": "0s",
      "role": "ami-f083709d",
      "region": "us-east-1",
      "nonce": "5defbf9e-a8f9-3063-bdfc-54b7a42a1f95",
      "instance_id": "i-a832f734",
      "ami_id": "ami-f083709d"
    },
    "policies": [
      "default",
      "dev",
      "prod"
    ],
    "accessor": "5cd96cd1-58b7-2904-5519-75ddf957ec06",
    "client_token": "150fc858-2402-49c9-56a5-f4b57f2c8ff1"
  },
  "warnings": null,
  "wrap_info": null,
  "data": null,
  "lease_duration": 0,
  "renewable": false,
  "lease_id": "",
  "request_id": "d7d50c06-56b8-37f4-606c-ccdc87a1ee4c"
}`