### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The driver is available from Maven Central, for all modern Java build systems.
 Gradle:
 ```
 dependencies {
-    compile('com.bettercloud:vault-java-driver:4.0.0')
+    implementation 'com.bettercloud:vault-java-driver:4.0.0'
 }
 ```
 


### PR DESCRIPTION
Following these instructions with the latest version of Android Studio and it complains that compile is now obsolete.
True enough the gradle documentation says the same thing:
https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation
```
The compile configuration still exists but should not be used as it will not offer the guarantees that the api and implementation configurations provide.
```