### PR TITLE
Adding the ability to not treat 4xx response codes as errors that sho…

### DIFF
--- a/src/main/java/com/bettercloud/vault/VaultConfig.java
+++ b/src/main/java/com/bettercloud/vault/VaultConfig.java
@@ -40,7 +40,6 @@ public class VaultConfig implements Serializable {
     private int retryIntervalMilliseconds;
     private Integer globalEngineVersion;
     private String nameSpace;
-    private Boolean treatInvalidRequestsAsErrors = true;
     private EnvironmentLoader environmentLoader;
 
     /**
@@ -209,26 +208,6 @@ public class VaultConfig implements Serializable {
     }
 
     /**
-     * <p>Specifies whether 4xx class status codes should be treated as errors or invalid calls.</p>
-     *
-     * <p>If 4xx status codes are treated as errors, any call that returns them will retry (if specified)
-     * and will result in an exception being thrown.  If disabled, a 4xx return code does not retry, does
-     * not generate an exception, and instead returns the error in the response body</p>
-     *
-     * <p>If you set this to <code>false</code> you need to check the response code before using the data
-     * in a response</p>
-     *
-     * <p>The default behavior is to treat 4xx status codes as errors.</p>
-     *
-     * @param treatInvalidRequestsAsErrors Should 4xx class status codes be treated as errors.
-     * @return This object, with treatInvalidRequestsAsErrors populated, ready for additional builder-pattern method calls or else finalization with the build() method
-     */
-    public VaultConfig treatInvalidRequestsAsErrors(final Boolean treatInvalidRequestsAsErrors) {
-        this.treatInvalidRequestsAsErrors = treatInvalidRequestsAsErrors;
-        return this;
-    }
-
-    /**
      * <p>Sets the maximum number of times that an API operation will retry upon failure.</p>
      *
      * <p>This method is not meant to be called from application-level code outside of this package (hence
@@ -333,10 +312,6 @@ public class VaultConfig implements Serializable {
 
     public Integer getReadTimeout() {
         return readTimeout;
-    }
-
-    public Boolean isTreatInvalidRequestsAsErrors() {
-        return treatInvalidRequestsAsErrors;
     }
 
     public int getMaxRetries() {

--- a/src/main/java/com/bettercloud/vault/VaultConfig.java
+++ b/src/main/java/com/bettercloud/vault/VaultConfig.java
@@ -40,6 +40,7 @@ public class VaultConfig implements Serializable {
     private int retryIntervalMilliseconds;
     private Integer globalEngineVersion;
     private String nameSpace;
+    private Boolean treatInvalidRequestsAsErrors = true;
     private EnvironmentLoader environmentLoader;
 
     /**
@@ -208,6 +209,26 @@ public class VaultConfig implements Serializable {
     }
 
     /**
+     * <p>Specifies whether 4xx class status codes should be treated as errors or invalid calls.</p>
+     *
+     * <p>If 4xx status codes are treated as errors, any call that returns them will retry (if specified)
+     * and will result in an exception being thrown.  If disabled, a 4xx return code does not retry, does
+     * not generate an exception, and instead returns the error in the response body</p>
+     *
+     * <p>If you set this to <code>false</code> you need to check the response code before using the data
+     * in a response</p>
+     *
+     * <p>The default behavior is to treat 4xx status codes as errors.</p>
+     *
+     * @param treatInvalidRequestsAsErrors Should 4xx class status codes be treated as errors.
+     * @return This object, with treatInvalidRequestsAsErrors populated, ready for additional builder-pattern method calls or else finalization with the build() method
+     */
+    public VaultConfig treatInvalidRequestsAsErrors(final Boolean treatInvalidRequestsAsErrors) {
+        this.treatInvalidRequestsAsErrors = treatInvalidRequestsAsErrors;
+        return this;
+    }
+
+    /**
      * <p>Sets the maximum number of times that an API operation will retry upon failure.</p>
      *
      * <p>This method is not meant to be called from application-level code outside of this package (hence
@@ -312,6 +333,10 @@ public class VaultConfig implements Serializable {
 
     public Integer getReadTimeout() {
         return readTimeout;
+    }
+
+    public Boolean isTreatInvalidRequestsAsErrors() {
+        return treatInvalidRequestsAsErrors;
     }
 
     public int getMaxRetries() {

--- a/src/main/java/com/bettercloud/vault/api/Logical.java
+++ b/src/main/java/com/bettercloud/vault/api/Logical.java
@@ -91,8 +91,8 @@ public class Logical {
                         .sslContext(config.getSslConfig().getSslContext())
                         .get();
 
-                // Validate response
-                if (restResponse.getStatus() != 200 && !(!config.isTreatInvalidRequestsAsErrors() && restResponse.getStatus() >= 400 && restResponse.getStatus() < 500)) {
+                // Validate response - don't treat 4xx class errors as exceptions, we want to return an error as the response
+                if (restResponse.getStatus() != 200 && !(restResponse.getStatus() >= 400 && restResponse.getStatus() < 500)) {
                     throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus()
                             + "\nResponse body: " + new String(restResponse.getBody(), StandardCharsets.UTF_8),
                             restResponse.getStatus());
@@ -160,8 +160,8 @@ public class Logical {
                         .sslContext(config.getSslConfig().getSslContext())
                         .get();
 
-                // Validate response
-                if (restResponse.getStatus() != 200 && !(!config.isTreatInvalidRequestsAsErrors() && restResponse.getStatus() >= 400 && restResponse.getStatus() < 500)) {
+                // Validate response - don't treat 4xx class errors as exceptions, we want to return an error as the response
+                if (restResponse.getStatus() != 200 && !(restResponse.getStatus() >= 400 && restResponse.getStatus() < 500)) {
                     throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus()
                             + "\nResponse body: " + new String(restResponse.getBody(), StandardCharsets.UTF_8),
                             restResponse.getStatus());
@@ -261,7 +261,7 @@ public class Logical {
 
                 // HTTP Status should be either 200 (with content - e.g. PKI write) or 204 (no content)
                 final int restStatus = restResponse.getStatus();
-                if (restStatus == 200 || restStatus == 204 || (!config.isTreatInvalidRequestsAsErrors() && restResponse.getStatus() >= 400 && restResponse.getStatus() < 500)) {
+                if (restStatus == 200 || restStatus == 204 || (restResponse.getStatus() >= 400 && restResponse.getStatus() < 500)) {
                     return new LogicalResponse(restResponse, retryCount, operation);
                 } else {
                     throw new VaultException("Expecting HTTP status 204 or 200, but instead receiving " + restStatus

--- a/src/main/java/com/bettercloud/vault/api/Logical.java
+++ b/src/main/java/com/bettercloud/vault/api/Logical.java
@@ -92,7 +92,7 @@ public class Logical {
                         .get();
 
                 // Validate response
-                if (restResponse.getStatus() != 200) {
+                if (restResponse.getStatus() != 200 && !(!config.isTreatInvalidRequestsAsErrors() && restResponse.getStatus() >= 400 && restResponse.getStatus() < 500)) {
                     throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus()
                             + "\nResponse body: " + new String(restResponse.getBody(), StandardCharsets.UTF_8),
                             restResponse.getStatus());
@@ -161,7 +161,7 @@ public class Logical {
                         .get();
 
                 // Validate response
-                if (restResponse.getStatus() != 200) {
+                if (restResponse.getStatus() != 200 && !(!config.isTreatInvalidRequestsAsErrors() && restResponse.getStatus() >= 400 && restResponse.getStatus() < 500)) {
                     throw new VaultException("Vault responded with HTTP status code: " + restResponse.getStatus()
                             + "\nResponse body: " + new String(restResponse.getBody(), StandardCharsets.UTF_8),
                             restResponse.getStatus());
@@ -261,7 +261,7 @@ public class Logical {
 
                 // HTTP Status should be either 200 (with content - e.g. PKI write) or 204 (no content)
                 final int restStatus = restResponse.getStatus();
-                if (restStatus == 200 || restStatus == 204) {
+                if (restStatus == 200 || restStatus == 204 || (!config.isTreatInvalidRequestsAsErrors() && restResponse.getStatus() >= 400 && restResponse.getStatus() < 500)) {
                     return new LogicalResponse(restResponse, retryCount, operation);
                 } else {
                     throw new VaultException("Expecting HTTP status 204 or 200, but instead receiving " + restStatus

--- a/src/test/java/com/bettercloud/vault/VaultConfigTests.java
+++ b/src/test/java/com/bettercloud/vault/VaultConfigTests.java
@@ -256,4 +256,12 @@ public class VaultConfigTests {
         Assert.assertEquals(vaultConfig.getNameSpace(), "namespace");
     }
 
+    @Test
+    public void testConfigBuiler_WithInvalidRequestAsNonError() throws VaultException {
+        VaultConfig vaultConfig = new VaultConfig().address("address").token("token").treatInvalidRequestsAsErrors(false).build();
+        assertEquals("address", vaultConfig.getAddress());
+        assertEquals("token", vaultConfig.getToken());
+        assertEquals(Boolean.FALSE, vaultConfig.isTreatInvalidRequestsAsErrors());
+
+    }
 }

--- a/src/test/java/com/bettercloud/vault/VaultConfigTests.java
+++ b/src/test/java/com/bettercloud/vault/VaultConfigTests.java
@@ -255,13 +255,4 @@ public class VaultConfigTests {
         VaultConfig vaultConfig = new VaultConfig().nameSpace("namespace").address("address").build();
         Assert.assertEquals(vaultConfig.getNameSpace(), "namespace");
     }
-
-    @Test
-    public void testConfigBuiler_WithInvalidRequestAsNonError() throws VaultException {
-        VaultConfig vaultConfig = new VaultConfig().address("address").token("token").treatInvalidRequestsAsErrors(false).build();
-        assertEquals("address", vaultConfig.getAddress());
-        assertEquals("token", vaultConfig.getToken());
-        assertEquals(Boolean.FALSE, vaultConfig.isTreatInvalidRequestsAsErrors());
-
-    }
 }


### PR DESCRIPTION
Adds support for not treating 4xx status coded from vaults as errors for reads/writes, and allows them to be passed back without retries or being converted to VaultExceptions.

Use Case:
We have a spring app with a custom property resolver that can read properties from various sources, and want to add Vault as a new source. If a property does not exist in vault, it should read it from the next source.  With the current version of vault-java-driver if the property is not in Vault it will retry the configured number of times, waiting between each retry, which significantly slows down the app startup.  This PR allows us to turn that off and get an immediate "no such value" from Vault.

If you would prefer, I could modify this to still throw an exception but just turn off the retry logic.