### PR TITLE
Add kv-v2 mount type

### DIFF
--- a/src/main/java/com/bettercloud/vault/api/mounts/MountType.java
+++ b/src/main/java/com/bettercloud/vault/api/mounts/MountType.java
@@ -17,6 +17,8 @@ public enum MountType {
 
     KEY_VALUE("kv"),
 
+    KEY_VALUE_V2("kv-v2"),
+
     IDENTITY("identity"),
 
     NOMAD("nomad"),


### PR DESCRIPTION
Add `kv-v2` mount type.
Mount type `kv` uses engine version 1, but by using `kv-v2` version 2 is used.