### PR TITLE
Changed the list() methods to return a LogicalResult so the status co…

### DIFF
--- a/src/main/java/com/bettercloud/vault/api/Logical.java
+++ b/src/main/java/com/bettercloud/vault/api/Logical.java
@@ -300,13 +300,13 @@ public class Logical {
      * @return A list of keys corresponding to key/value pairs at a given Vault path, or an empty list if there are none
      * @throws VaultException If any errors occur, or unexpected response received from Vault
      */
-    public List<String> list(final String path) throws VaultException {
+    public LogicalResponse list(final String path) throws VaultException {
         if (engineVersionForSecretPath(path).equals(2)) {
             return list(path, logicalOperations.listV2);
         } else return list(path, logicalOperations.listV1);
     }
 
-    private List<String> list(final String path, final logicalOperations operation) throws VaultException {
+    private LogicalResponse list(final String path, final logicalOperations operation) throws VaultException {
         LogicalResponse response = null;
         try {
             response = read(adjustPathForList(path, operation), true, operation);
@@ -316,20 +316,7 @@ public class Logical {
             }
         }
 
-        final List<String> returnValues = new ArrayList<>();
-        if (
-                response != null
-                        && response.getRestResponse().getStatus() != 404
-                        && response.getData() != null
-                        && response.getData().get("keys") != null
-        ) {
-
-            final JsonArray keys = Json.parse(response.getData().get("keys")).asArray();
-            for (int index = 0; index < keys.size(); index++) {
-                returnValues.add(keys.get(index).asString());
-            }
-        }
-        return returnValues;
+        return response;
     }
 
     /**

--- a/src/main/java/com/bettercloud/vault/response/LogicalResponse.java
+++ b/src/main/java/com/bettercloud/vault/response/LogicalResponse.java
@@ -2,12 +2,15 @@ package com.bettercloud.vault.response;
 
 import com.bettercloud.vault.api.Logical;
 import com.bettercloud.vault.json.Json;
+import com.bettercloud.vault.json.JsonArray;
 import com.bettercloud.vault.json.JsonObject;
 import com.bettercloud.vault.json.JsonValue;
 import com.bettercloud.vault.rest.RestResponse;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -17,6 +20,7 @@ import java.util.Map;
 public class LogicalResponse extends VaultResponse {
 
     private Map<String, String> data = new HashMap<>();
+    private List<String> listData = new ArrayList<>();
     private JsonObject dataObject = null;
     private String leaseId;
     private Boolean renewable;
@@ -35,6 +39,10 @@ public class LogicalResponse extends VaultResponse {
 
     public Map<String, String> getData() {
         return data;
+    }
+
+    public List<String> getListData() {
+        return listData;
     }
 
     public JsonObject getDataObject() {
@@ -83,6 +91,20 @@ public class LogicalResponse extends VaultResponse {
                 } else {
                     data.put(member.getName(), jsonValue.toString());
                 }
+            }
+            // For list operations convert the array of keys to a list of values
+            if (operation.equals(Logical.logicalOperations.listV1) || operation.equals(Logical.logicalOperations.listV2)) {
+                if (
+                        getRestResponse().getStatus() != 404
+                                && data.get("keys") != null
+                ) {
+
+                    final JsonArray keys = Json.parse(data.get("keys")).asArray();
+                    for (int index = 0; index < keys.size(); index++) {
+                        listData.add(keys.get(index).asString());
+                    }
+                }
+
             }
         } catch (Exception ignored) {
         }

--- a/src/test-integration/java/com/bettercloud/vault/api/LogicalTests.java
+++ b/src/test-integration/java/com/bettercloud/vault/api/LogicalTests.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.response.AuthResponse;
+import com.bettercloud.vault.response.LogicalResponse;
 import com.bettercloud.vault.util.VaultContainer;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -165,7 +166,7 @@ public class LogicalTests {
         testMap.put("value", "world");
 
         vault.logical().write("secret/hello", testMap);
-        final List<String> keys = vault.logical().list("secret");
+        final List<String> keys = vault.logical().list("secret").getListData();
         assertTrue(keys.contains("hello"));
     }
 
@@ -181,7 +182,7 @@ public class LogicalTests {
         testMap.put("value", "world");
 
         vault.logical().write("kv-v1/hello", testMap);
-        final List<String> keys = vault.logical().list("kv-v1");
+        final List<String> keys = vault.logical().list("kv-v1").getListData();
         assertTrue(keys.contains("hello"));
     }
 
@@ -197,9 +198,9 @@ public class LogicalTests {
         testMap.put("value", "world");
 
         vault.logical().write("secret/hello", testMap);
-        assertTrue(vault.logical().list("secret").contains("hello"));
+        assertTrue(vault.logical().list("secret").getListData().contains("hello"));
         vault.logical().delete("secret/hello");
-        assertFalse(vault.logical().list("secret").contains("hello"));
+        assertFalse(vault.logical().list("secret").getListData().contains("hello"));
     }
 
     /**
@@ -214,9 +215,9 @@ public class LogicalTests {
         testMap.put("value", "world");
 
         vault.logical().write("kv-v1/hello", testMap);
-        assertTrue(vault.logical().list("kv-v1").contains("hello"));
+        assertTrue(vault.logical().list("kv-v1").getListData().contains("hello"));
         vault.logical().delete("kv-v1/hello");
-        assertFalse(vault.logical().list("kv-v1").contains("hello"));
+        assertFalse(vault.logical().list("kv-v1").getListData().contains("hello"));
     }
 
     /**
@@ -302,7 +303,8 @@ public class LogicalTests {
         expectedEx.expectMessage("permission denied");
 
         final Vault vault = container.getVault(NONROOT_TOKEN);
-        vault.logical().list("secret/null");
+        LogicalResponse response = vault.logical().list("secret/null");
+        assertEquals(404, response.getRestResponse().getStatus());
     }
 
     /**


### PR DESCRIPTION
This PR changes the return type of the Logical list() methods to be a LogicalResult instead of a List of Strings, and adds a new method to the LogicalResponse that can be used to access the list.  Tests have been updated to work with the new API