### PR TITLE
#158 Proxy support

### DIFF
--- a/src/main/java/com/bettercloud/vault/Vault.java
+++ b/src/main/java/com/bettercloud/vault/Vault.java
@@ -253,7 +253,7 @@ public class Vault {
         try {
             final RestResponse restResponse = new Rest()//NOPMD
                     .url(vaultConfig.getAddress() + "/v1/sys/mounts")
-                    .proxy(vaultConfig.getProxy())
+                    .proxy(vaultConfig.getProxy(), vaultConfig.getProxyAuth())
                     .header("X-Vault-Token", vaultConfig.getToken())
                     .header("X-Vault-Namespace", this.vaultConfig.getNameSpace())
                     .connectTimeoutSeconds(vaultConfig.getOpenTimeout())

--- a/src/main/java/com/bettercloud/vault/Vault.java
+++ b/src/main/java/com/bettercloud/vault/Vault.java
@@ -253,6 +253,7 @@ public class Vault {
         try {
             final RestResponse restResponse = new Rest()//NOPMD
                     .url(vaultConfig.getAddress() + "/v1/sys/mounts")
+                    .proxy(vaultConfig.getProxy())
                     .header("X-Vault-Token", vaultConfig.getToken())
                     .header("X-Vault-Namespace", this.vaultConfig.getNameSpace())
                     .connectTimeoutSeconds(vaultConfig.getOpenTimeout())

--- a/src/main/java/com/bettercloud/vault/VaultConfig.java
+++ b/src/main/java/com/bettercloud/vault/VaultConfig.java
@@ -1,6 +1,8 @@
 package com.bettercloud.vault;
 
 import java.io.Serializable;
+import java.net.Proxy;
+import java.net.ProxySelector;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -34,6 +36,7 @@ public class VaultConfig implements Serializable {
     private String address;
     private String token;
     private SslConfig sslConfig;
+    private Proxy proxy;
     private Integer openTimeout;
     private Integer readTimeout;
     private int maxRetries;
@@ -112,6 +115,19 @@ public class VaultConfig implements Serializable {
         if (this.address.endsWith("/")) {
             this.address = this.address.substring(0, this.address.length() - 1);
         }
+        return this;
+    }
+
+    /**
+     * <p>Sets the proxy to use to connect to the Vault server.</p>
+     *
+     * <p>If a {@code null} proxy is specified then the JRE default proxy selection algorithm will be used, e.g. {@link ProxySelector#getDefault()}</p>
+     *
+     * @param proxy  proxy the proxy to use or {@code null} to let the JRE select the proxy (which normally defaults to {@link ProxySelector#getDefault()}
+     * @return This object, with proxy populated, ready for additional builder-pattern method calls or else finalization with the build() method
+     */
+    public VaultConfig proxy(final Proxy proxy) {
+        this.proxy = proxy;
         return this;
     }
 
@@ -296,6 +312,10 @@ public class VaultConfig implements Serializable {
 
     public String getAddress() {
         return address;
+    }
+
+    public Proxy getProxy() {
+        return proxy;
     }
 
     public String getToken() {

--- a/src/main/java/com/bettercloud/vault/VaultConfig.java
+++ b/src/main/java/com/bettercloud/vault/VaultConfig.java
@@ -37,6 +37,7 @@ public class VaultConfig implements Serializable {
     private String token;
     private SslConfig sslConfig;
     private Proxy proxy;
+    private String proxyAuth;
     private Integer openTimeout;
     private Integer readTimeout;
     private int maxRetries;
@@ -128,6 +129,22 @@ public class VaultConfig implements Serializable {
      */
     public VaultConfig proxy(final Proxy proxy) {
         this.proxy = proxy;
+        this.proxyAuth = null;
+        return this;
+    }
+
+    /**
+     * <p>Sets the proxy to use to connect to the Vault server.</p>
+     *
+     * <p>If a {@code null} proxy is specified then the JRE default proxy selection algorithm will be used, e.g. {@link ProxySelector#getDefault()}</p>
+     *
+     * @param proxy  proxy the proxy to use or {@code null} to let the JRE select the proxy (which normally defaults to {@link ProxySelector#getDefault()}
+     * @param proxyAuth the {@code Proxy-Authenticate} header to supply for authenticated proxies.
+     * @return This object, with proxy populated, ready for additional builder-pattern method calls or else finalization with the build() method
+     */
+    public VaultConfig proxy(final Proxy proxy, String proxyAuth) {
+        this.proxy = proxy;
+        this.proxyAuth = proxyAuth;
         return this;
     }
 
@@ -316,6 +333,10 @@ public class VaultConfig implements Serializable {
 
     public Proxy getProxy() {
         return proxy;
+    }
+
+    public String getProxyAuth() {
+        return proxyAuth;
     }
 
     public String getToken() {

--- a/src/main/java/com/bettercloud/vault/api/Auth.java
+++ b/src/main/java/com/bettercloud/vault/api/Auth.java
@@ -263,6 +263,7 @@ public class Auth {
                 // HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(url)
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
@@ -330,6 +331,7 @@ public class Auth {
                 final String requestJson = Json.object().add("app_id", appId).add("user_id", userId).toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + path)
+                        .proxy(config.getProxy())
                         .optionalHeader("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -424,6 +426,7 @@ public class Auth {
                 final String requestJson = Json.object().add("role_id", roleId).add("secret_id", secretId).toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + path + "/login")
+                        .proxy(config.getProxy())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -507,6 +510,7 @@ public class Auth {
                 final String requestJson = Json.object().add("password", password).toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/login/" + username)
+                        .proxy(config.getProxy())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -629,6 +633,7 @@ public class Auth {
 
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/login")
+                        .proxy(config.getProxy())
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -705,6 +710,7 @@ public class Auth {
                 final String requestJson = request.toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/login")
+                        .proxy(config.getProxy())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -784,6 +790,7 @@ public class Auth {
                 final String requestJson = request.toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/login")
+                        .proxy(config.getProxy())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -869,6 +876,7 @@ public class Auth {
                 final String requestJson = Json.object().add("token", githubToken).toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/login")
+                        .proxy(config.getProxy())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -933,6 +941,7 @@ public class Auth {
                 final String requestJson = Json.object().add("role", role).add("jwt", jwt).toString();
                 final RestResponse restResponse = new Rest()
                         .url(config.getAddress() + "/v1/auth/" + provider + "/login")
+                        .proxy(config.getProxy())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -1073,6 +1082,7 @@ public class Auth {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/login")
+                        .proxy(config.getProxy())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
                         .readTimeoutSeconds(config.getReadTimeout())
@@ -1154,6 +1164,7 @@ public class Auth {
                 final String requestJson = Json.object().add("increment", increment).toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/renew-self")
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(increment < 0 ? null : requestJson.getBytes(StandardCharsets.UTF_8))
@@ -1217,6 +1228,7 @@ public class Auth {
                 // HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/lookup-self")
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -1279,6 +1291,7 @@ public class Auth {
                 // HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/wrapping/lookup")
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -1341,6 +1354,7 @@ public class Auth {
                 // HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/revoke-self")
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -1442,6 +1456,7 @@ public class Auth {
                 // HTTP request to Vault
                 final RestResponse restResponse = new Rest()
                         .url(url)
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))

--- a/src/main/java/com/bettercloud/vault/api/Auth.java
+++ b/src/main/java/com/bettercloud/vault/api/Auth.java
@@ -263,7 +263,7 @@ public class Auth {
                 // HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(url)
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
@@ -331,7 +331,7 @@ public class Auth {
                 final String requestJson = Json.object().add("app_id", appId).add("user_id", userId).toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + path)
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .optionalHeader("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -426,7 +426,7 @@ public class Auth {
                 final String requestJson = Json.object().add("role_id", roleId).add("secret_id", secretId).toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + path + "/login")
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -510,7 +510,7 @@ public class Auth {
                 final String requestJson = Json.object().add("password", password).toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/login/" + username)
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -633,7 +633,7 @@ public class Auth {
 
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/login")
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -710,7 +710,7 @@ public class Auth {
                 final String requestJson = request.toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/login")
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -790,7 +790,7 @@ public class Auth {
                 final String requestJson = request.toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/login")
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -876,7 +876,7 @@ public class Auth {
                 final String requestJson = Json.object().add("token", githubToken).toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/login")
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -941,7 +941,7 @@ public class Auth {
                 final String requestJson = Json.object().add("role", role).add("jwt", jwt).toString();
                 final RestResponse restResponse = new Rest()
                         .url(config.getAddress() + "/v1/auth/" + provider + "/login")
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -1082,7 +1082,7 @@ public class Auth {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/login")
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
                         .readTimeoutSeconds(config.getReadTimeout())
@@ -1164,7 +1164,7 @@ public class Auth {
                 final String requestJson = Json.object().add("increment", increment).toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/renew-self")
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(increment < 0 ? null : requestJson.getBytes(StandardCharsets.UTF_8))
@@ -1228,7 +1228,7 @@ public class Auth {
                 // HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/lookup-self")
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -1291,7 +1291,7 @@ public class Auth {
                 // HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/wrapping/lookup")
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -1354,7 +1354,7 @@ public class Auth {
                 // HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/auth/" + mount + "/revoke-self")
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -1456,7 +1456,7 @@ public class Auth {
                 // HTTP request to Vault
                 final RestResponse restResponse = new Rest()
                         .url(url)
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))

--- a/src/main/java/com/bettercloud/vault/api/Debug.java
+++ b/src/main/java/com/bettercloud/vault/api/Debug.java
@@ -90,7 +90,7 @@ public class Debug {
                 // Build an HTTP request for Vault
                 final Rest rest = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + path)
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())

--- a/src/main/java/com/bettercloud/vault/api/Debug.java
+++ b/src/main/java/com/bettercloud/vault/api/Debug.java
@@ -90,6 +90,7 @@ public class Debug {
                 // Build an HTTP request for Vault
                 final Rest rest = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + path)
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())

--- a/src/main/java/com/bettercloud/vault/api/Leases.java
+++ b/src/main/java/com/bettercloud/vault/api/Leases.java
@@ -61,7 +61,7 @@ public class Leases {
                 */
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/leases/revoke/" + leaseId)
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -117,7 +117,7 @@ public class Leases {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/revoke-prefix/" + prefix)
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -176,7 +176,7 @@ public class Leases {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/revoke-force/" + prefix)
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -240,7 +240,7 @@ public class Leases {
                 final String requestJson = Json.object().add("increment", increment).toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/renew/" + leaseId)
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(increment < 0 ? null : requestJson.getBytes(StandardCharsets.UTF_8))

--- a/src/main/java/com/bettercloud/vault/api/Leases.java
+++ b/src/main/java/com/bettercloud/vault/api/Leases.java
@@ -61,6 +61,7 @@ public class Leases {
                 */
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/leases/revoke/" + leaseId)
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -116,6 +117,7 @@ public class Leases {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/revoke-prefix/" + prefix)
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -174,6 +176,7 @@ public class Leases {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/revoke-force/" + prefix)
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -237,6 +240,7 @@ public class Leases {
                 final String requestJson = Json.object().add("increment", increment).toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/renew/" + leaseId)
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(increment < 0 ? null : requestJson.getBytes(StandardCharsets.UTF_8))

--- a/src/main/java/com/bettercloud/vault/api/Logical.java
+++ b/src/main/java/com/bettercloud/vault/api/Logical.java
@@ -88,6 +88,7 @@ public class Logical {
                 // Make an HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + adjustPathForReadOrWrite(path, operation))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -156,6 +157,7 @@ public class Logical {
                 // Make an HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + adjustPathForReadOrWrite(path, logicalOperations.readV2))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .parameter("version", version.toString())
@@ -255,6 +257,7 @@ public class Logical {
                 // Make an HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + adjustPathForReadOrWrite(path, operation))
+                        .proxy(config.getProxy())
                         .body(jsonObjectToWriteFromEngineVersion(operation, requestJson).toString().getBytes(StandardCharsets.UTF_8))
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
@@ -347,6 +350,7 @@ public class Logical {
                 // Make an HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + adjustPathForDelete(path, operation))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -407,6 +411,7 @@ public class Logical {
                 JsonObject versionsToDelete = new JsonObject().add("versions", versions);
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + adjustPathForVersionDelete(path))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -478,6 +483,7 @@ public class Logical {
                 JsonObject versionsToUnDelete = new JsonObject().add("versions", versions);
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + adjustPathForVersionUnDelete(path))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -537,6 +543,7 @@ public class Logical {
                 JsonObject versionsToDestroy = new JsonObject().add("versions", versions);
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + adjustPathForVersionDestroy(path))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -588,6 +595,7 @@ public class Logical {
                 JsonObject kvToUpgrade = new JsonObject().add("options", new JsonObject().add("version", 2));
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/mounts/" + (kvPath.replaceAll("/", "") + "/tune"))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())

--- a/src/main/java/com/bettercloud/vault/api/Logical.java
+++ b/src/main/java/com/bettercloud/vault/api/Logical.java
@@ -88,7 +88,7 @@ public class Logical {
                 // Make an HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + adjustPathForReadOrWrite(path, operation))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -157,7 +157,7 @@ public class Logical {
                 // Make an HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + adjustPathForReadOrWrite(path, logicalOperations.readV2))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .parameter("version", version.toString())
@@ -257,7 +257,7 @@ public class Logical {
                 // Make an HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + adjustPathForReadOrWrite(path, operation))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .body(jsonObjectToWriteFromEngineVersion(operation, requestJson).toString().getBytes(StandardCharsets.UTF_8))
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
@@ -350,7 +350,7 @@ public class Logical {
                 // Make an HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + adjustPathForDelete(path, operation))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -411,7 +411,7 @@ public class Logical {
                 JsonObject versionsToDelete = new JsonObject().add("versions", versions);
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + adjustPathForVersionDelete(path))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -483,7 +483,7 @@ public class Logical {
                 JsonObject versionsToUnDelete = new JsonObject().add("versions", versions);
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + adjustPathForVersionUnDelete(path))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -543,7 +543,7 @@ public class Logical {
                 JsonObject versionsToDestroy = new JsonObject().add("versions", versions);
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + adjustPathForVersionDestroy(path))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -595,7 +595,7 @@ public class Logical {
                 JsonObject kvToUpgrade = new JsonObject().add("options", new JsonObject().add("version", 2));
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/mounts/" + (kvPath.replaceAll("/", "") + "/tune"))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())

--- a/src/main/java/com/bettercloud/vault/api/Seal.java
+++ b/src/main/java/com/bettercloud/vault/api/Seal.java
@@ -46,7 +46,7 @@ public class Seal {
                 // HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/seal")
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -108,7 +108,7 @@ public class Seal {
                 final String requestJson = Json.object().add("key", key).add("reset", reset).toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/unseal")
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -152,7 +152,7 @@ public class Seal {
                 // HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/seal-status")
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
                         .readTimeoutSeconds(config.getReadTimeout())

--- a/src/main/java/com/bettercloud/vault/api/Seal.java
+++ b/src/main/java/com/bettercloud/vault/api/Seal.java
@@ -46,6 +46,7 @@ public class Seal {
                 // HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/seal")
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -107,6 +108,7 @@ public class Seal {
                 final String requestJson = Json.object().add("key", key).add("reset", reset).toString();
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/unseal")
+                        .proxy(config.getProxy())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -150,6 +152,7 @@ public class Seal {
                 // HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/sys/seal-status")
+                        .proxy(config.getProxy())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
                         .readTimeoutSeconds(config.getReadTimeout())

--- a/src/main/java/com/bettercloud/vault/api/database/Database.java
+++ b/src/main/java/com/bettercloud/vault/api/database/Database.java
@@ -84,7 +84,7 @@ public class Database {
 
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath, roleName))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
@@ -147,7 +147,7 @@ public class Database {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath, roleName))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -215,7 +215,7 @@ public class Database {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/revoke", config.getAddress(), this.mountPath))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -278,7 +278,7 @@ public class Database {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath, roleName))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -339,7 +339,7 @@ public class Database {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/creds/%s", config.getAddress(), this.mountPath, roleName))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())

--- a/src/main/java/com/bettercloud/vault/api/database/Database.java
+++ b/src/main/java/com/bettercloud/vault/api/database/Database.java
@@ -84,6 +84,7 @@ public class Database {
 
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath, roleName))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
@@ -146,6 +147,7 @@ public class Database {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath, roleName))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -213,6 +215,7 @@ public class Database {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/revoke", config.getAddress(), this.mountPath))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -275,6 +278,7 @@ public class Database {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath, roleName))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -335,6 +339,7 @@ public class Database {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/creds/%s", config.getAddress(), this.mountPath, roleName))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())

--- a/src/main/java/com/bettercloud/vault/api/mounts/Mounts.java
+++ b/src/main/java/com/bettercloud/vault/api/mounts/Mounts.java
@@ -48,6 +48,7 @@ public class Mounts {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/sys/mounts", config.getAddress()))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .connectTimeoutSeconds(config.getOpenTimeout())
                         .readTimeoutSeconds(config.getReadTimeout())
@@ -133,6 +134,7 @@ public class Mounts {
 
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/sys/mounts/%s", config.getAddress(), path))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -200,6 +202,7 @@ public class Mounts {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/sys/mounts/%s", config.getAddress(), path))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .connectTimeoutSeconds(config.getOpenTimeout())
                         .readTimeoutSeconds(config.getReadTimeout())
@@ -266,6 +269,7 @@ public class Mounts {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/sys/mounts/%s/tune", config.getAddress(), path))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .connectTimeoutSeconds(config.getOpenTimeout())
                         .readTimeoutSeconds(config.getReadTimeout())
@@ -347,6 +351,7 @@ public class Mounts {
 
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/sys/mounts/%s/tune", config.getAddress(), path))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())

--- a/src/main/java/com/bettercloud/vault/api/mounts/Mounts.java
+++ b/src/main/java/com/bettercloud/vault/api/mounts/Mounts.java
@@ -48,7 +48,7 @@ public class Mounts {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/sys/mounts", config.getAddress()))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .connectTimeoutSeconds(config.getOpenTimeout())
                         .readTimeoutSeconds(config.getReadTimeout())
@@ -134,7 +134,7 @@ public class Mounts {
 
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/sys/mounts/%s", config.getAddress(), path))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -202,7 +202,7 @@ public class Mounts {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/sys/mounts/%s", config.getAddress(), path))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .connectTimeoutSeconds(config.getOpenTimeout())
                         .readTimeoutSeconds(config.getReadTimeout())
@@ -269,7 +269,7 @@ public class Mounts {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/sys/mounts/%s/tune", config.getAddress(), path))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .connectTimeoutSeconds(config.getOpenTimeout())
                         .readTimeoutSeconds(config.getReadTimeout())
@@ -351,7 +351,7 @@ public class Mounts {
 
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/sys/mounts/%s/tune", config.getAddress(), path))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
                         .connectTimeoutSeconds(config.getOpenTimeout())

--- a/src/main/java/com/bettercloud/vault/api/pki/Pki.java
+++ b/src/main/java/com/bettercloud/vault/api/pki/Pki.java
@@ -114,7 +114,7 @@ public class Pki {
 
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath, roleName))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
@@ -177,7 +177,7 @@ public class Pki {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath, roleName))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -245,7 +245,7 @@ public class Pki {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/revoke", config.getAddress(), this.mountPath))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -308,7 +308,7 @@ public class Pki {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath, roleName))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -465,7 +465,7 @@ public class Pki {
                 String endpoint = (csr == null || csr.isEmpty()) ? "%s/v1/%s/issue/%s" : "%s/v1/%s/sign/%s";
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format(endpoint, config.getAddress(), this.mountPath, roleName))
-                        .proxy(config.getProxy())
+                        .proxy(config.getProxy(), config.getProxyAuth())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))

--- a/src/main/java/com/bettercloud/vault/api/pki/Pki.java
+++ b/src/main/java/com/bettercloud/vault/api/pki/Pki.java
@@ -114,6 +114,7 @@ public class Pki {
 
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath, roleName))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))
@@ -176,6 +177,7 @@ public class Pki {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath, roleName))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -243,6 +245,7 @@ public class Pki {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/revoke", config.getAddress(), this.mountPath))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -305,6 +308,7 @@ public class Pki {
             try {
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath, roleName))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -461,6 +465,7 @@ public class Pki {
                 String endpoint = (csr == null || csr.isEmpty()) ? "%s/v1/%s/issue/%s" : "%s/v1/%s/sign/%s";
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(String.format(endpoint, config.getAddress(), this.mountPath, roleName))
+                        .proxy(config.getProxy())
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .body(requestJson.getBytes(StandardCharsets.UTF_8))

--- a/src/main/java/com/bettercloud/vault/rest/Rest.java
+++ b/src/main/java/com/bettercloud/vault/rest/Rest.java
@@ -101,6 +101,7 @@ public class Rest {
     private Boolean sslVerification;
     private SSLContext sslContext;
     private Proxy proxy;
+    private String proxyAuth;
 
     /**
      * <p>Sets the base URL to which the HTTP request will be sent.  The URL may or may not include query parameters
@@ -125,10 +126,12 @@ public class Rest {
      *
      * @param proxy the proxy to use or {@code null} to let the JRE select the proxy (which normally defaults to
      * {@link ProxySelector#getDefault()}
+     * @param proxyAuth the {@code Proxy-Authenticate} header value to apply or {@code null} to let the JRE attempt authentication.
      * @return This object, with proxy populated, ready for other builder-pattern config methods or an HTTP verb method
      */
-    public Rest proxy(final Proxy proxy) {
+    public Rest proxy(final Proxy proxy, final String proxyAuth) {
         this.proxy = proxy;
+        this.proxyAuth = proxyAuth;
         return this;
     }
 
@@ -447,7 +450,15 @@ public class Rest {
         URLConnection connection = null;
         try {
             final URL url = new URL(urlString);
-            connection = proxy == null ? url.openConnection() : url.openConnection(proxy);
+            if (proxy == null) {
+                connection = url.openConnection();
+            } else {
+                connection = url.openConnection(proxy);
+                if (proxyAuth != null) {
+                    connection.setRequestProperty("Proxy-Authenticate", proxyAuth);
+                }
+            }
+
 
             // Timeout settings, if applicable
             if (connectTimeoutSeconds != null) {

--- a/src/main/java/com/bettercloud/vault/rest/Rest.java
+++ b/src/main/java/com/bettercloud/vault/rest/Rest.java
@@ -6,6 +6,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
+import java.net.Proxy;
+import java.net.ProxySelector;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
@@ -98,6 +100,7 @@ public class Rest {
     private Integer readTimeoutSeconds;
     private Boolean sslVerification;
     private SSLContext sslContext;
+    private Proxy proxy;
 
     /**
      * <p>Sets the base URL to which the HTTP request will be sent.  The URL may or may not include query parameters
@@ -113,6 +116,19 @@ public class Rest {
      */
     public Rest url(final String urlString) {
         this.urlString = urlString;
+        return this;
+    }
+
+    /**
+     * <p>Override the JRE default proxy selector and sets the {@link Proxy} that will be used for the HTTP request.
+     * If set to {@code null} then the JRE default proxy selection {@link ProxySelector#getDefault()} will ultimately be used</p>
+     *
+     * @param proxy the proxy to use or {@code null} to let the JRE select the proxy (which normally defaults to
+     * {@link ProxySelector#getDefault()}
+     * @return This object, with proxy populated, ready for other builder-pattern config methods or an HTTP verb method
+     */
+    public Rest proxy(final Proxy proxy) {
+        this.proxy = proxy;
         return this;
     }
 
@@ -431,7 +447,7 @@ public class Rest {
         URLConnection connection = null;
         try {
             final URL url = new URL(urlString);
-            connection = url.openConnection();
+            connection = proxy == null ? url.openConnection() : url.openConnection(proxy);
 
             // Timeout settings, if applicable
             if (connectTimeoutSeconds != null) {


### PR DESCRIPTION
Unclear if this is wanted, but here is my suggestion of a zero-dep idiomatic proxy support addition to your API.

Notes/Rationale:

* Use of things like proxy properties is kind of bad. People who need to use a proxy to access Vault may not want the proxy configuration globally set for the JDK.

* Similarly, the current API behaviour of implicitly relying on the `ProxySelector.getDefault()` through `URL.openConnection()` is rather evil as this means that the only way to control the proxy requires race conditions with other JDK code, nevermind that in some cases the JRE permissions may have blocked `setProxySelector` from the application.

* The JRE's `Proxy` class does not encapsulate proxy authentication but is otherwise sufficiently generic that it should be ok.

* With regards to proxy authentication, this can be a tricky problem, for example if Kerberos authentication is configured on the proxy. For this reason I am suggesting either to leave proxy authentication out (first commit on PR) or to just expose the ability to configure the `Proxy-Authenticate` header (second commit on PR)... a fancier solution would be to change the `proxyAuth` field from a `String` to a `Supplier<String>` to enable per-request header generation... though anyone with that complex a need is probably better off just creating a new `Vault` instance for each request anyway!