### PR TITLE
Change the logic for mapping paths to engine versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'checkstyle'
 
 group 'com.bettercloud'
 archivesBaseName = 'vault-java-driver'
-version '5.0.0'
+version '5.0.1'
 ext.isReleaseVersion = !version.endsWith('SNAPSHOT')
 
 // This project is actually limited to Java 8 compatibility.  See below.

--- a/src/main/java/com/bettercloud/vault/api/Logical.java
+++ b/src/main/java/com/bettercloud/vault/api/Logical.java
@@ -3,17 +3,15 @@ package com.bettercloud.vault.api;
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
 import com.bettercloud.vault.json.Json;
-import com.bettercloud.vault.json.JsonArray;
 import com.bettercloud.vault.json.JsonObject;
 import com.bettercloud.vault.response.LogicalResponse;
 import com.bettercloud.vault.rest.Rest;
 import com.bettercloud.vault.rest.RestException;
 import com.bettercloud.vault.rest.RestResponse;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import static com.bettercloud.vault.api.LogicalUtilities.adjustPathForDelete;
 import static com.bettercloud.vault.api.LogicalUtilities.adjustPathForList;
@@ -626,9 +624,11 @@ public class Logical {
 
     private Integer engineVersionForSecretPath(final String secretPath) {
         if (!this.config.getSecretsEnginePathMap().isEmpty()) {
-            return this.config.getSecretsEnginePathMap().containsKey(secretPath + "/") ?
-                    Integer.valueOf(this.config.getSecretsEnginePathMap().get(secretPath + "/"))
-                    : this.config.getGlobalEngineVersion();
+            for (Entry<String, String> entry : this.config.getSecretsEnginePathMap().entrySet()) {
+                if (secretPath.startsWith(entry.getKey())) {
+                    return Integer.valueOf(entry.getValue());
+                }
+            }
         }
         return this.config.getGlobalEngineVersion();
     }


### PR DESCRIPTION
Change the logic for mapping paths to engine versions to use path prefix instead of the absolute path match