### PR TITLE
fixing bulk requests in the transit api

### DIFF
--- a/src/main/java/com/bettercloud/vault/api/Logical.java
+++ b/src/main/java/com/bettercloud/vault/api/Logical.java
@@ -5,6 +5,7 @@ import com.bettercloud.vault.VaultException;
 import com.bettercloud.vault.json.Json;
 import com.bettercloud.vault.json.JsonArray;
 import com.bettercloud.vault.json.JsonObject;
+import com.bettercloud.vault.json.JsonValue;
 import com.bettercloud.vault.response.LogicalResponse;
 import com.bettercloud.vault.rest.Rest;
 import com.bettercloud.vault.rest.RestException;
@@ -247,6 +248,8 @@ public class Logical {
                             requestJson = requestJson.add(pair.getKey(), (Float) pair.getValue());
                         } else if (value instanceof Double) {
                             requestJson = requestJson.add(pair.getKey(), (Double) pair.getValue());
+                        } else if (value instanceof JsonValue) {
+                            requestJson = requestJson.add(pair.getKey(), (JsonValue) pair.getValue());
                         } else {
                             requestJson = requestJson.add(pair.getKey(), pair.getValue().toString());
                         }

--- a/src/test/java/com/bettercloud/vault/vault/api/TransitApiTest.java
+++ b/src/test/java/com/bettercloud/vault/vault/api/TransitApiTest.java
@@ -1,0 +1,160 @@
+package com.bettercloud.vault.vault.api;
+
+import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.VaultConfig;
+import com.bettercloud.vault.json.JsonArray;
+import com.bettercloud.vault.json.JsonObject;
+import com.bettercloud.vault.response.LogicalResponse;
+import com.bettercloud.vault.vault.VaultTestUtils;
+import com.bettercloud.vault.vault.mock.MockVault;
+import org.eclipse.jetty.server.Server;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+public class TransitApiTest {
+
+    private static final String[] PLAIN_DATA = {"MU45MjIyMTM=", "MU45MjIxMTM=", "MA=="};
+
+    private static final String[] CIPHER_DATA = {
+        "1jFhRYWHiddSKgEFyVRpX8ieX7UU+748NBw",
+        "1jFhRYWHiddSKgEFyVRpX8ieX7UU+748NBw",
+        "HKecXE3hnGBoAxrfgoD5U0yAvji7b5X6V1fP"
+    };
+
+    private Server server;
+    private MockVault vaultServer;
+
+    public void start(String response) throws Exception {
+        vaultServer = new MockVault(200, response);
+        server = VaultTestUtils.initHttpMockVault(vaultServer);
+        server.start();
+    }
+
+    @After
+    public void after() throws Exception {
+        VaultTestUtils.shutdownMockVault(server);
+    }
+
+    @Test
+    public void testTransitEncrypt() throws Exception {
+        final JsonObject expectedRequest = new JsonObject()
+                .add("plaintext", PLAIN_DATA[0]);
+        final JsonObject expectedResponse = new JsonObject()
+                .add("data", new JsonObject()
+                        .add("ciphertext", CIPHER_DATA[0]));
+
+        start(expectedResponse.toString());
+
+        final VaultConfig vaultConfig = new VaultConfig()
+                .address("http://127.0.0.1:8999")
+                .build();
+        final Vault vault = new Vault(vaultConfig, 1);
+
+        LogicalResponse response = vault.logical().write("transit/encrypt/test",
+                Collections.singletonMap("plaintext", PLAIN_DATA[0]));
+
+        assertEquals("http://127.0.0.1:8999/v1/transit/encrypt/test", vaultServer.getRequestUrl());
+        assertEquals(Optional.of(expectedRequest), vaultServer.getRequestBody());
+        assertEquals(200, response.getRestResponse().getStatus());
+    }
+
+    @Test
+    public void testTransitDecrypt() throws Exception {
+        final JsonObject expectedRequest = new JsonObject()
+                .add("ciphertext", CIPHER_DATA[0]);
+        final JsonObject expectedResponse = new JsonObject()
+                .add("data", new JsonObject()
+                        .add("plaintext", PLAIN_DATA[0]));
+
+        start(expectedResponse.toString());
+
+        final VaultConfig vaultConfig = new VaultConfig()
+                .address("http://127.0.0.1:8999")
+                .build();
+        final Vault vault = new Vault(vaultConfig, 1);
+
+        LogicalResponse response = vault.logical().write("transit/decrypt/test",
+                Collections.singletonMap("ciphertext", CIPHER_DATA[0]));
+
+        assertEquals("http://127.0.0.1:8999/v1/transit/decrypt/test", vaultServer.getRequestUrl());
+        assertEquals(Optional.of(expectedRequest), vaultServer.getRequestBody());
+        assertEquals(200, response.getRestResponse().getStatus());
+    }
+
+    @Test
+    public void testBulkTransitEncrypt() throws Exception {
+        JsonArray batchRequest = new JsonArray();
+        for (String text : PLAIN_DATA) {
+            batchRequest.add(new JsonObject().add("plaintext", text));
+        }
+        JsonArray batchResponse = new JsonArray();
+        for (String text : CIPHER_DATA) {
+            batchResponse.add(new JsonObject().add("ciphertext", text));
+        }
+        final JsonObject expectedRequest = new JsonObject()
+                .add("batch_input", batchRequest);
+        final JsonObject expectedResponse = new JsonObject()
+                .add("data", new JsonObject()
+                        .add("batch_results", batchResponse));
+
+        start(expectedResponse.toString());
+
+        final VaultConfig vaultConfig = new VaultConfig()
+                .address("http://127.0.0.1:8999")
+                .build();
+        final Vault vault = new Vault(vaultConfig, 1);
+
+        JsonArray batch = new JsonArray();
+        for (String text : PLAIN_DATA) {
+            batch.add(new JsonObject().add("plaintext", text));
+        }
+        LogicalResponse response = vault.logical().write("transit/encrypt/test",
+                Collections.singletonMap("batch_input", batch));
+
+        assertEquals(Optional.of(expectedRequest), vaultServer.getRequestBody());
+        assertEquals("http://127.0.0.1:8999/v1/transit/encrypt/test", vaultServer.getRequestUrl());
+        assertEquals(200, response.getRestResponse().getStatus());
+    }
+
+    @Test
+    public void testBulkTransitDecrypt() throws Exception {
+        JsonArray batchRequest = new JsonArray();
+        for (String text : CIPHER_DATA) {
+            batchRequest.add(new JsonObject().add("ciphertext", text));
+        }
+        JsonArray batchResponse = new JsonArray();
+        for (String text : PLAIN_DATA) {
+            batchResponse.add(new JsonObject().add("plaintext", text));
+        }
+        final JsonObject expectedRequest = new JsonObject()
+                .add("batch_input", batchRequest);
+        final JsonObject expectedResponse = new JsonObject()
+                .add("data", new JsonObject()
+                    .add("batch_results", batchResponse));
+
+        start(expectedResponse.toString());
+
+        final VaultConfig vaultConfig = new VaultConfig()
+                .address("http://127.0.0.1:8999")
+                .build();
+        final Vault vault = new Vault(vaultConfig, 1);
+
+        JsonArray batch = new JsonArray();
+        for (String text : CIPHER_DATA) {
+            batch.add(new JsonObject().add("ciphertext", text));
+        }
+        LogicalResponse response = vault.logical().write("transit/decrypt/test",
+                Collections.singletonMap("batch_input", batch));
+
+        assertEquals(Optional.of(expectedRequest), vaultServer.getRequestBody());
+        assertEquals("http://127.0.0.1:8999/v1/transit/decrypt/test", vaultServer.getRequestUrl());
+        assertEquals(200, response.getRestResponse().getStatus());
+    }
+
+}


### PR DESCRIPTION
The transit api fails on bulk requests since the write function in Logical expects only a scalar type and not a JsonValue. The problem can be seen by commenting my fix and running the tests I added.

The fix will allow transit bulk APIs to work as well as any current of future vault requests that have a nested JSON in the request.