### PR TITLE
#179 fix path for latest-version v2 kv delete

### DIFF
--- a/src/main/java/com/bettercloud/vault/api/LogicalUtilities.java
+++ b/src/main/java/com/bettercloud/vault/api/LogicalUtilities.java
@@ -125,7 +125,7 @@ public class LogicalUtilities {
         final List<String> pathSegments = getPathSegments(path);
         if (operation.equals(Logical.logicalOperations.deleteV2)) {
             final StringBuilder adjustedPath = new StringBuilder(
-                    addQualifierToPath(pathSegments, prefixPathDepth, "metadata"));
+                    addQualifierToPath(pathSegments, prefixPathDepth, "data"));
             if (path.endsWith("/")) {
                 adjustedPath.append("/");
             }


### PR DESCRIPTION
Current code attempts a DELETE on the `metadata` path to do kv delete of the latest version,
but Vault expects a DELETE on the `data` path.

From the Vault API docs (https://www.vaultproject.io/api/secret/kv/kv-v2.html#delete-latest-version-of-secret):

»Delete Latest Version of Secret

This endpoint issues a soft delete of the secret's latest version at the specified
location. This marks the version as deleted and will stop it from being returned
from reads, but the underlying data will not be removed. A delete can be undone
using the undelete path.

Method	Path
DELETE	/secret/data/:path