### PR TITLE
Ensure writes to VaultConfig and SslConfig are guaranteed to be visible to other threads

### DIFF
--- a/src/main/java/com/bettercloud/vault/SslConfig.java
+++ b/src/main/java/com/bettercloud/vault/SslConfig.java
@@ -44,16 +44,16 @@ public class SslConfig implements Serializable {
     private static final String VAULT_SSL_VERIFY = "VAULT_SSL_VERIFY";
     private static final String VAULT_SSL_CERT = "VAULT_SSL_CERT";
 
-    private boolean verify;
-    private transient SSLContext sslContext;
-    private transient KeyStore trustStore;
-    private transient KeyStore keyStore;
-    private String keyStorePassword;
-    private String pemUTF8;  // exposed to unit tests
-    private String clientPemUTF8;
-    private String clientKeyPemUTF8;
-    private Boolean verifyObject;
-    private EnvironmentLoader environmentLoader;
+    private volatile boolean verify;
+    private volatile transient SSLContext sslContext;
+    private volatile transient KeyStore trustStore;
+    private volatile transient KeyStore keyStore;
+    private volatile String keyStorePassword;
+    private volatile String pemUTF8;  // exposed to unit tests
+    private volatile String clientPemUTF8;
+    private volatile String clientKeyPemUTF8;
+    private volatile Boolean verifyObject;
+    private volatile EnvironmentLoader environmentLoader;
 
     /**
      * <p>The code used to load environment variables is encapsulated here, so that a mock version of that environment

--- a/src/main/java/com/bettercloud/vault/VaultConfig.java
+++ b/src/main/java/com/bettercloud/vault/VaultConfig.java
@@ -30,18 +30,18 @@ public class VaultConfig implements Serializable {
     private static final String VAULT_OPEN_TIMEOUT = "VAULT_OPEN_TIMEOUT";
     private static final String VAULT_READ_TIMEOUT = "VAULT_READ_TIMEOUT";
 
-    private Map<String, String> secretsEnginePathMap = new ConcurrentHashMap<>();
-    private String address;
-    private String token;
-    private SslConfig sslConfig;
-    private Integer openTimeout;
-    private Integer readTimeout;
-    private int prefixPathDepth = 1;
-    private int maxRetries;
-    private int retryIntervalMilliseconds;
-    private Integer globalEngineVersion;
-    private String nameSpace;
-    private EnvironmentLoader environmentLoader;
+    private volatile Map<String, String> secretsEnginePathMap = new ConcurrentHashMap<>();
+    private volatile String address;
+    private volatile String token;
+    private volatile SslConfig sslConfig;
+    private volatile Integer openTimeout;
+    private volatile Integer readTimeout;
+    private volatile int prefixPathDepth = 1;
+    private volatile int maxRetries;
+    private volatile int retryIntervalMilliseconds;
+    private volatile Integer globalEngineVersion;
+    private volatile String nameSpace;
+    private volatile EnvironmentLoader environmentLoader;
 
     /**
      * <p>The code used to load environment variables is encapsulated here, so that a mock version of that environment


### PR DESCRIPTION
#46 

Hi Team,

This is just a minor change to ensure the variables are visible to other threads. (as per Java Memory Model: https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.3.1.4)

While I understand that the vault client is mostly not designed to be multi-threaded, there is a use case where this might still be useful:
1. Consider the task of token renewal for a long running service, that uses the vault client in irregular intervals.
2. In order to ensure the vault token is still valid regardless of the interval, one would need to schedule the renewal call periodically. However, in java this means that one would need to start a background scheduler thread (either manually, scheduled executors or framework support).
3. This means that the vault client will at least be used by 1 other thread (main & scheduler thread) and more than 1 thread would be accessing the fields in the VaultConfig/ SslConfig.
4. Assuming, that one does not mutate the VaultConfig after construction in the main thread (and initializing calls are made to set the retries once), currently, there is still no guarantee that the scheduler thread will be able to see the values set by the main thread.

The fix makes all the variables volatile to ensure that all threads always see a consistent value after any particular write (there will still be race conditions if the variables are mutated by different threads, but that's not an issue for this use case).

I think this is an easy fix for a use case, where I think might be quite common for long running services. It is also hard to detect, as different architectures and different JVMs might behave differently.

While as much as possible I would adopt the one vault per thread approach, it seems unavoidable to do so for this use case, hence the fix.

Thanks for the time and for creating this Library!