### PR TITLE
Expose "check and set" write option and secret version to read (K/V 2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'checkstyle'
 
 group 'com.bettercloud'
 archivesBaseName = 'vault-java-driver'
-version '5.1.0'
+version '5.2.0'
 ext.isReleaseVersion = !version.endsWith('SNAPSHOT')
 
 // This project is actually limited to Java 8 compatibility.  See below.

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'checkstyle'
 
 group 'com.bettercloud'
 archivesBaseName = 'vault-java-driver'
-version '5.2.0'
+version '5.1.0'
 ext.isReleaseVersion = !version.endsWith('SNAPSHOT')
 
 // This project is actually limited to Java 8 compatibility.  See below.

--- a/src/main/java/com/bettercloud/vault/api/Logical.java
+++ b/src/main/java/com/bettercloud/vault/api/Logical.java
@@ -219,42 +219,31 @@ public class Logical {
      */
     public LogicalResponse write(final String path, final Map<String, Object> nameValuePairs) throws VaultException {
         if (engineVersionForSecretPath(path).equals(2)) {
-            return write(path, nameValuePairs, logicalOperations.writeV2);
-        } else return write(path, nameValuePairs, logicalOperations.writeV1);
+            return write(path, nameValuePairs, logicalOperations.writeV2, null);
+        } else return write(path, nameValuePairs, logicalOperations.writeV1, null);
+    }
+
+    public LogicalResponse write(final String path, final Map<String, Object> nameValuePairs,
+                                 final Map<String, Object> writeOptions) throws VaultException {
+        if (this.engineVersionForSecretPath(path) != 2) {
+            throw new VaultException("Write options are only supported in KV Engine version 2.");
+        }
+        return write(path, nameValuePairs, logicalOperations.writeV2, writeOptions);
     }
 
     private LogicalResponse write(final String path, final Map<String, Object> nameValuePairs,
-                                  final logicalOperations operation) throws VaultException {
+                                  final logicalOperations operation,
+                                  final Map<String, Object> writeOptions) throws VaultException {
         int retryCount = 0;
         while (true) {
             try {
-                JsonObject requestJson = Json.object();
-                if (nameValuePairs != null) {
-                    for (final Map.Entry<String, Object> pair : nameValuePairs.entrySet()) {
-                        final Object value = pair.getValue();
-                        if (value == null) {
-                            requestJson = requestJson.add(pair.getKey(), (String) null);
-                        } else if (value instanceof Boolean) {
-                            requestJson = requestJson.add(pair.getKey(), (Boolean) pair.getValue());
-                        } else if (value instanceof Integer) {
-                            requestJson = requestJson.add(pair.getKey(), (Integer) pair.getValue());
-                        } else if (value instanceof Long) {
-                            requestJson = requestJson.add(pair.getKey(), (Long) pair.getValue());
-                        } else if (value instanceof Float) {
-                            requestJson = requestJson.add(pair.getKey(), (Float) pair.getValue());
-                        } else if (value instanceof Double) {
-                            requestJson = requestJson.add(pair.getKey(), (Double) pair.getValue());
-                        } else if (value instanceof JsonValue) {
-                            requestJson = requestJson.add(pair.getKey(), (JsonValue) pair.getValue());
-                        } else {
-                            requestJson = requestJson.add(pair.getKey(), pair.getValue().toString());
-                        }
-                    }
-                }
+                JsonObject dataJson = buildJsonFromMap(nameValuePairs);
+                JsonObject optionsJson = ((writeOptions != null) && (writeOptions.size() > 0)) ? buildJsonFromMap(writeOptions) : null;
+
                 // Make an HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD
                         .url(config.getAddress() + "/v1/" + adjustPathForReadOrWrite(path, config.getPrefixPathDepth(), operation))
-                        .body(jsonObjectToWriteFromEngineVersion(operation, requestJson).toString().getBytes(StandardCharsets.UTF_8))
+                        .body(jsonObjectToWriteFromEngineVersion(operation, dataJson, optionsJson).toString().getBytes(StandardCharsets.UTF_8))
                         .header("X-Vault-Token", config.getToken())
                         .header("X-Vault-Namespace", this.nameSpace)
                         .connectTimeoutSeconds(config.getOpenTimeout())
@@ -644,4 +633,32 @@ public class Logical {
     public Integer getEngineVersionForSecretPath(final String path) {
         return this.engineVersionForSecretPath(path);
     }
+
+    private JsonObject buildJsonFromMap(Map<String, Object> nameValuePairs) {
+        JsonObject jsonObject = Json.object();
+        if (nameValuePairs != null) {
+            for (final Map.Entry<String, Object> pair : nameValuePairs.entrySet()) {
+                final Object value = pair.getValue();
+                if (value == null) {
+                    jsonObject = jsonObject.add(pair.getKey(), (String) null);
+                } else if (value instanceof Boolean) {
+                    jsonObject = jsonObject.add(pair.getKey(), (Boolean) pair.getValue());
+                } else if (value instanceof Integer) {
+                    jsonObject = jsonObject.add(pair.getKey(), (Integer) pair.getValue());
+                } else if (value instanceof Long) {
+                    jsonObject = jsonObject.add(pair.getKey(), (Long) pair.getValue());
+                } else if (value instanceof Float) {
+                    jsonObject = jsonObject.add(pair.getKey(), (Float) pair.getValue());
+                } else if (value instanceof Double) {
+                    jsonObject = jsonObject.add(pair.getKey(), (Double) pair.getValue());
+                } else if (value instanceof JsonValue) {
+                    jsonObject = jsonObject.add(pair.getKey(), (JsonValue) pair.getValue());
+                } else {
+                    jsonObject = jsonObject.add(pair.getKey(), pair.getValue().toString());
+                }
+            }
+        }
+        return jsonObject;
+    }
+
 }

--- a/src/main/java/com/bettercloud/vault/api/Logical.java
+++ b/src/main/java/com/bettercloud/vault/api/Logical.java
@@ -29,6 +29,8 @@ import static com.bettercloud.vault.api.LogicalUtilities.jsonObjectToWriteFromEn
  */
 public class Logical {
 
+    private static final WriteOptions EMPTY_WRITE_OPTIONS = WriteOptions.emptyOptions();
+
     private final VaultConfig config;
 
     private String nameSpace;
@@ -219,12 +221,12 @@ public class Logical {
      */
     public LogicalResponse write(final String path, final Map<String, Object> nameValuePairs) throws VaultException {
         if (engineVersionForSecretPath(path).equals(2)) {
-            return write(path, nameValuePairs, logicalOperations.writeV2, null);
-        } else return write(path, nameValuePairs, logicalOperations.writeV1, null);
+            return write(path, nameValuePairs, logicalOperations.writeV2, EMPTY_WRITE_OPTIONS);
+        } else return write(path, nameValuePairs, logicalOperations.writeV1, EMPTY_WRITE_OPTIONS);
     }
 
     public LogicalResponse write(final String path, final Map<String, Object> nameValuePairs,
-                                 final Map<String, Object> writeOptions) throws VaultException {
+                                 final WriteOptions writeOptions) throws VaultException {
         if (this.engineVersionForSecretPath(path) != 2) {
             throw new VaultException("Write options are only supported in KV Engine version 2.");
         }
@@ -233,12 +235,12 @@ public class Logical {
 
     private LogicalResponse write(final String path, final Map<String, Object> nameValuePairs,
                                   final logicalOperations operation,
-                                  final Map<String, Object> writeOptions) throws VaultException {
+                                  final WriteOptions writeOptions) throws VaultException {
         int retryCount = 0;
         while (true) {
             try {
                 JsonObject dataJson = buildJsonFromMap(nameValuePairs);
-                JsonObject optionsJson = ((writeOptions != null) && (writeOptions.size() > 0)) ? buildJsonFromMap(writeOptions) : null;
+                JsonObject optionsJson = writeOptions.isEmpty() ? null : buildJsonFromMap(writeOptions.getOptionsMap());
 
                 // Make an HTTP request to Vault
                 final RestResponse restResponse = new Rest()//NOPMD

--- a/src/main/java/com/bettercloud/vault/api/Logical.java
+++ b/src/main/java/com/bettercloud/vault/api/Logical.java
@@ -29,7 +29,7 @@ import static com.bettercloud.vault.api.LogicalUtilities.jsonObjectToWriteFromEn
  */
 public class Logical {
 
-    private static final WriteOptions EMPTY_WRITE_OPTIONS = WriteOptions.emptyOptions();
+    private static final WriteOptions EMPTY_WRITE_OPTIONS = new WriteOptions().build();
 
     private final VaultConfig config;
 

--- a/src/main/java/com/bettercloud/vault/api/LogicalUtilities.java
+++ b/src/main/java/com/bettercloud/vault/api/LogicalUtilities.java
@@ -198,13 +198,18 @@ public class LogicalUtilities {
      * @return This jsonObject mutated for the operation.
      */
     public static JsonObject jsonObjectToWriteFromEngineVersion(
-            final Logical.logicalOperations operation, final JsonObject jsonObject) {
+            final Logical.logicalOperations operation, final JsonObject jsonObject,
+            final JsonObject optionsJsonObject) {
         if (operation.equals(Logical.logicalOperations.writeV2)) {
             final JsonObject wrappedJson = new JsonObject();
             wrappedJson.add("data", jsonObject);
+            if (null != optionsJsonObject) {
+                wrappedJson.add("options", optionsJsonObject);
+            }
             return wrappedJson;
         } else {
             return jsonObject;
         }
     }
+
 }

--- a/src/main/java/com/bettercloud/vault/api/LogicalUtilities.java
+++ b/src/main/java/com/bettercloud/vault/api/LogicalUtilities.java
@@ -191,10 +191,12 @@ public class LogicalUtilities {
     }
 
     /**
-     * In version two, when writing a secret, the JSONObject must be nested with "data" as the key.
+     * In version two, when writing a secret, the JSONObject must be nested with "data" as the key
+     * and an "options" key may be optionally provided
      *
      * @param operation The operation being performed, e.g. writeV1, or writeV2.
      * @param jsonObject The jsonObject that is going to be written.
+     * @param optionsJsonObject The options jsonObject that is going to be written or null if none
      * @return This jsonObject mutated for the operation.
      */
     public static JsonObject jsonObjectToWriteFromEngineVersion(

--- a/src/main/java/com/bettercloud/vault/api/WriteOptions.java
+++ b/src/main/java/com/bettercloud/vault/api/WriteOptions.java
@@ -1,0 +1,37 @@
+package com.bettercloud.vault.api;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class WriteOptions {
+
+    public static final String CHECK_AND_SET_KEY = "cas";
+
+    private final Map<String, Object> options = new HashMap<>();
+
+    public WriteOptions checkAndSet(Long version) {
+        return setOption(CHECK_AND_SET_KEY, version);
+    }
+
+    public WriteOptions setOption(String name, Object value) {
+        options.put(name, value);
+        return this;
+    }
+
+    public WriteOptions build() {
+        return this;
+    }
+
+    public Map<String, Object> getOptionsMap() {
+        return Collections.unmodifiableMap(options);
+    }
+
+    public boolean isEmpty() {
+        return options.isEmpty();
+    }
+
+    public static WriteOptions emptyOptions() {
+        return new WriteOptions().build();
+    }
+}

--- a/src/main/java/com/bettercloud/vault/api/WriteOptions.java
+++ b/src/main/java/com/bettercloud/vault/api/WriteOptions.java
@@ -31,7 +31,4 @@ public class WriteOptions {
         return options.isEmpty();
     }
 
-    public static WriteOptions emptyOptions() {
-        return new WriteOptions().build();
-    }
 }

--- a/src/main/java/com/bettercloud/vault/response/DataMetadata.java
+++ b/src/main/java/com/bettercloud/vault/response/DataMetadata.java
@@ -1,0 +1,29 @@
+package com.bettercloud.vault.response;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class DataMetadata {
+
+    public static final String VERSION_KEY = "version";
+
+    private final Map<String, String> metadataMap;
+
+    public DataMetadata(Map<String, String> metadataMap) {
+        this.metadataMap = metadataMap;
+    }
+
+    public Long getVersion() {
+        final String versionString = metadataMap.get(VERSION_KEY);
+        return (null != versionString) ? Long.valueOf(versionString) : null;
+    }
+
+    public Map<String, String> getMetadataMap() {
+        return Collections.unmodifiableMap(metadataMap);
+    }
+
+    public boolean isEmpty() {
+        return metadataMap.isEmpty();
+    }
+
+}

--- a/src/main/java/com/bettercloud/vault/response/LogicalResponse.java
+++ b/src/main/java/com/bettercloud/vault/response/LogicalResponse.java
@@ -83,16 +83,15 @@ public class LogicalResponse extends VaultResponse {
             JsonObject jsonObject = Json.parse(jsonString).asObject();
             if (operation.equals(Logical.logicalOperations.readV2)) {
                 jsonObject = jsonObject.get("data").asObject();
+
+                JsonValue metadataValue = jsonObject.get("metadata");
+                if (null != metadataValue) {
+                    parseJsonIntoMap(metadataValue.asObject(), dataMetadata);
+                }
             }
             data = new HashMap<>();
             dataObject = jsonObject.get("data").asObject();
             parseJsonIntoMap(dataObject, data);
-
-            JsonValue metadataValue = jsonObject.get("metadata");
-            if (null != metadataValue) {
-                JsonObject metadataObject = metadataValue.asObject();
-                parseJsonIntoMap(metadataObject, dataMetadata);
-            }
 
             // For list operations convert the array of keys to a list of values
             if (operation.equals(Logical.logicalOperations.listV1) || operation.equals(Logical.logicalOperations.listV2)) {

--- a/src/main/java/com/bettercloud/vault/response/LogicalResponse.java
+++ b/src/main/java/com/bettercloud/vault/response/LogicalResponse.java
@@ -24,7 +24,7 @@ public class LogicalResponse extends VaultResponse {
     private String leaseId;
     private Boolean renewable;
     private Long leaseDuration;
-    private final Map<String, String> metadata = new HashMap<>();
+    private final Map<String, String> dataMetadata = new HashMap<>();
 
     /**
      * @param restResponse The raw HTTP response from Vault.
@@ -61,8 +61,8 @@ public class LogicalResponse extends VaultResponse {
         return leaseDuration;
     }
 
-    public Map<String, String> getMetadata() {
-        return metadata;
+    public DataMetadata getDataMetadata() {
+        return new DataMetadata(dataMetadata);
     }
 
     private void parseMetadataFields() {
@@ -91,7 +91,7 @@ public class LogicalResponse extends VaultResponse {
             JsonValue metadataValue = jsonObject.get("metadata");
             if (null != metadataValue) {
                 JsonObject metadataObject = metadataValue.asObject();
-                parseJsonIntoMap(metadataObject, metadata);
+                parseJsonIntoMap(metadataObject, dataMetadata);
             }
 
             // For list operations convert the array of keys to a list of values

--- a/src/test-integration/java/com/bettercloud/vault/api/AuthBackendTokenTests.java
+++ b/src/test-integration/java/com/bettercloud/vault/api/AuthBackendTokenTests.java
@@ -9,7 +9,6 @@ import com.bettercloud.vault.util.VaultContainer;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;

--- a/src/test/java/com/bettercloud/vault/LogicalUtilitiesTests.java
+++ b/src/test/java/com/bettercloud/vault/LogicalUtilitiesTests.java
@@ -105,6 +105,12 @@ public class LogicalUtilitiesTests {
         JsonObject jsonObjectV2 = new JsonObject().add("test", "test");
         JsonObject jsonObjectFromEngineVersionV2 = LogicalUtilities.jsonObjectToWriteFromEngineVersion(Logical.logicalOperations.writeV2, jsonObjectV2, null);
         Assert.assertEquals(jsonObjectFromEngineVersionV2.get("data"), jsonObjectV2);
+        Assert.assertNull(jsonObjectFromEngineVersionV2.get("options"));
+
+        JsonObject optionsJsonObject = new JsonObject().add("cas", "0");
+        JsonObject jsonObjectFromEngineVersion2WithOptions = LogicalUtilities.jsonObjectToWriteFromEngineVersion(Logical.logicalOperations.writeV2, jsonObjectV2, optionsJsonObject);
+        Assert.assertEquals(jsonObjectFromEngineVersion2WithOptions.get("data"), jsonObjectV2);
+        Assert.assertEquals(jsonObjectFromEngineVersion2WithOptions.get("options"), optionsJsonObject);
 
         JsonObject jsonObjectV1 = new JsonObject().add("test", "test");
         JsonObject jsonObjectFromEngineVersionV1 = LogicalUtilities.jsonObjectToWriteFromEngineVersion(Logical.logicalOperations.writeV1, jsonObjectV1, null);

--- a/src/test/java/com/bettercloud/vault/LogicalUtilitiesTests.java
+++ b/src/test/java/com/bettercloud/vault/LogicalUtilitiesTests.java
@@ -103,11 +103,11 @@ public class LogicalUtilitiesTests {
     @Test
     public void jsonObjectToWriteFromEngineVersionTests() {
         JsonObject jsonObjectV2 = new JsonObject().add("test", "test");
-        JsonObject jsonObjectFromEngineVersionV2 = LogicalUtilities.jsonObjectToWriteFromEngineVersion(Logical.logicalOperations.writeV2, jsonObjectV2);
+        JsonObject jsonObjectFromEngineVersionV2 = LogicalUtilities.jsonObjectToWriteFromEngineVersion(Logical.logicalOperations.writeV2, jsonObjectV2, null);
         Assert.assertEquals(jsonObjectFromEngineVersionV2.get("data"), jsonObjectV2);
 
         JsonObject jsonObjectV1 = new JsonObject().add("test", "test");
-        JsonObject jsonObjectFromEngineVersionV1 = LogicalUtilities.jsonObjectToWriteFromEngineVersion(Logical.logicalOperations.writeV1, jsonObjectV1);
+        JsonObject jsonObjectFromEngineVersionV1 = LogicalUtilities.jsonObjectToWriteFromEngineVersion(Logical.logicalOperations.writeV1, jsonObjectV1, null);
         Assert.assertNull(jsonObjectFromEngineVersionV1.get("data"));
     }
 


### PR DESCRIPTION
* Expose the the "check and set" option for optimistic locking behavior on secret write operation
* Expose the secret version from the metadata block on secret read operation response so it can be used for "check and set"

Corresponding API documentation https://www.vaultproject.io/api/secret/kv/kv-v2.html
