### PR TITLE
Added the following

### DIFF
--- a/src/main/java/com/bettercloud/vault/api/pki/Pki.java
+++ b/src/main/java/com/bettercloud/vault/api/pki/Pki.java
@@ -374,8 +374,9 @@ public class Pki {
             final String ttl,
             final CredentialFormat format) throws VaultException {
 
-        return issue(roleName, commonName, altNames, ipSans, ttl, format, "");
+        return issue(roleName, commonName, altNames, ipSans, ttl, format, true, "");
     }
+
 
     /**
      * <p>Operation to generate a new set of credentials or sign the embedded CSR, in the PKI backend. If CSR is passed the
@@ -407,6 +408,49 @@ public class Pki {
      * @return A container for the information returned by Vault
      * @throws VaultException If any error occurs or unexpected response is received from Vault
      */
+    public PkiResponse issue(
+            final String roleName,
+            final String commonName,
+            final List<String> altNames,
+            final List<String> ipSans,
+            final String ttl,
+            final CredentialFormat format,
+            final String csr
+    ) throws VaultException {
+        return issue(roleName, commonName, altNames, ipSans, ttl, format, true, csr);
+    }
+
+    /**
+     * <p>Operation to generate a new set of credentials or sign the embedded CSR, in the PKI backend. If CSR is passed the
+     * sign function of the vault will be called if not, issue will be used.
+     * The issuing CA certificate is returned as well, so that only the root CA need be in a
+     * client's trust store.</p>
+     *
+     * <p>A successful operation will return a 204 HTTP status.  A <code>VaultException</code> will be thrown if
+     * the role does not exist, or if any other problem occurs.  Credential information will be populated in the
+     * <code>credential</code> field of the <code>PkiResponse</code> return value.  Example usage:</p>
+     *
+     * <blockquote>
+     * <pre>{@code
+     * final VaultConfig config = new VaultConfig.address(...).token(...).build();
+     * final Vault vault = new Vault(config);
+     *
+     * final PkiResponse response = vault.pki().deleteRole("testRole");
+     * assertEquals(204, response.getRestResponse().getStatus();
+     * }</pre>
+     * </blockquote>
+     *
+     * @param roleName          The role on which the credentials will be based.
+     * @param commonName        The requested CN for the certificate. If the CN is allowed by role policy, it will be issued.
+     * @param altNames          (optional) Requested Subject Alternative Names, in a comma-delimited list. These can be host names or email addresses; they will be parsed into their respective fields. If any requested names do not match role policy, the entire request will be denied.
+     * @param ipSans            (optional) Requested IP Subject Alternative Names, in a comma-delimited list. Only valid if the role allows IP SANs (which is the default).
+     * @param ttl               (optional) Requested Time To Live. Cannot be greater than the role's max_ttl value. If not provided, the role's ttl value will be used. Note that the role values default to system values if not explicitly set.
+     * @param format            (optional) Format for returned data. Can be pem, der, or pem_bundle; defaults to pem. If der, the output is base64 encoded. If pem_bundle, the certificate field will contain the private key, certificate, and issuing CA, concatenated.
+     * @param excludeCNFromSans (optional) Whether to use Verbatim (HashiCorp Vault UI, not sign-verbatim). If false then it will include 'excludeCNFromSans: false' in the request, otherwise it will not be included.
+     * @param csr               (optional) PEM Encoded CSR
+     * @return A container for the information returned by Vault
+     * @throws VaultException If any error occurs or unexpected response is received from Vault
+     */
 
 
     public PkiResponse issue(
@@ -416,6 +460,7 @@ public class Pki {
             final List<String> ipSans,
             final String ttl,
             final CredentialFormat format,
+            final boolean excludeCNFromSans,
             final String csr
     ) throws VaultException {
         int retryCount = 0;
@@ -453,6 +498,9 @@ public class Pki {
             }
             if (csr != null) {
                 jsonObject.add("csr", csr);
+                if (!excludeCNFromSans) {
+                    jsonObject.add("exclude_cn_from_sans", false);
+                }
             }
             final String requestJson = jsonObject.toString();
 

--- a/src/test-integration/java/com/bettercloud/vault/api/AuthBackendTokenTests.java
+++ b/src/test-integration/java/com/bettercloud/vault/api/AuthBackendTokenTests.java
@@ -9,7 +9,6 @@ import com.bettercloud.vault.util.VaultContainer;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;

--- a/src/test/java/com/bettercloud/vault/vault/api/TransitApiTest.java
+++ b/src/test/java/com/bettercloud/vault/vault/api/TransitApiTest.java
@@ -7,13 +7,11 @@ import com.bettercloud.vault.json.JsonObject;
 import com.bettercloud.vault.response.LogicalResponse;
 import com.bettercloud.vault.vault.VaultTestUtils;
 import com.bettercloud.vault.vault.mock.MockVault;
-import org.eclipse.jetty.server.Server;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.Collections;
 import java.util.Optional;
+import org.eclipse.jetty.server.Server;
+import org.junit.After;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
Added the following
  - `excludeCNFromSans` to provide the same functionality as the UI to bypass an issue I am having with HC Vault Sign operation and SubjectDN greater than 63 characters in CSR
Updated the following tests to remove the issues reported by Checkstyle
  - AuthBackendTokenTests
  - TransitApiTest

This relates to 
- https://github.com/BetterCloud/vault-java-driver/issues/244
- https://github.com/hashicorp/vault/issues/11721