### PR TITLE
Do not set the Accept-Charset HTTP Header as it's a "forbidden" header

### DIFF
--- a/src/main/java/com/bettercloud/vault/rest/Rest.java
+++ b/src/main/java/com/bettercloud/vault/rest/Rest.java
@@ -390,7 +390,6 @@ public class Rest {
             }
 
             connection.setDoOutput(true);
-            connection.setRequestProperty("Accept-Charset", "UTF-8");
 
             // If a body payload has been provided, then it takes precedence.  Otherwise, look for any additional
             // parameters to send as form field values.  Parameters sent via the base URL query string are left


### PR DESCRIPTION
This is documented at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Charset

See also OWASP ModSecurity core ruleset SecRule REQUEST_HEADERS:Accept : https://github.com/coreruleset/coreruleset/blob/v3.3/master/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf#L1147 